### PR TITLE
NEXT-10020 - Add a new twig block around buy button in product card. …

### DIFF
--- a/changelog/_unreleased/2020-09-17-new-twig-block-around-buy-button.md
+++ b/changelog/_unreleased/2020-09-17-new-twig-block-around-buy-button.md
@@ -1,0 +1,9 @@
+---
+title: New twig block around buy button
+issue: NEXT-10020
+author: Timo Helmke
+author_email: t.helmke@kellerkinder.de 
+author_github: @t2oh4e
+---
+# Storefront
+* Added a new block `page_product_detail_product_buy_button` in `src/Storefront/Resources/views/storefront/component/product/card/action.html.twig

--- a/src/Storefront/Resources/views/storefront/component/product/card/action.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/product/card/action.html.twig
@@ -58,10 +58,12 @@
                                            value="{{ product.translated.name }}">
                                 {% endblock %}
 
-                                <button class="btn btn-block btn-buy"
-                                        title="{{ "listing.boxAddProduct"|trans|striptags }}">
-                                    {{ "listing.boxAddProduct"|trans|sw_sanitize }}
-                                </button>
+                                {% block page_product_detail_product_buy_button %}
+                                    <button class="btn btn-block btn-buy"
+                                            title="{{ "listing.boxAddProduct"|trans|striptags }}">
+                                        {{ "listing.boxAddProduct"|trans|sw_sanitize }}
+                                    </button>
+                                {% endblock %}
                             {% endblock %}
                         </form>
                 {% endblock %}


### PR DESCRIPTION
…Fixes #2.

<!--
Thank you for contributing to the Shopware BoostDay! Please fill out this description template to help us to process your pull request.

Important! Please make sure your PRs follows the following structure:
-My commit(s) look like this "next-XXXX/my-commit-massage" (next-xxxx is found in the title of the issue)
-My title looks something like this "NEXT-XXXX - Issue name" (You can use the same Title as in the issue you're dealing with)

Please make sure to fulfil our general contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/contribution/contribution-guideline?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->


### 1. What does this change do, exactly?
Adds a new block to edit the buy button without needing to overwrite the whole template.

### 2. Describe each step to reproduce the issue or behaviour.
Try to change the buy button in your theme or plugin. You will need to overwrite the whole template to do so.

### 3. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/master/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
