### PR TITLE
NEXT-10918 - Add entity repository autowiring

### DIFF
--- a/changelog/_unreleased/2020-09-17-add-support-for-repository-autowiring.md
+++ b/changelog/_unreleased/2020-09-17-add-support-for-repository-autowiring.md
@@ -1,0 +1,24 @@
+---
+title:  Add support for autowiring of entity repositories
+issue:  NEXT-10918
+author:             Hendrik Söbbing
+author_email:       hendrik@soebbing.de
+author_github:      @soebbing
+---
+# Core
+* Changed `\Shopware\Core\Framework\DependencyInjection\CompilerPass\EntityCompilerPass` to also register an alias for arguments
+___
+# Upgrade Information
+
+## Entity Repository Autowiring
+
+The DAL entity repositories can now be injected into your services using autowiring. Necessary for this to work
+(apart from having your service configured for [autowiring](https://symfony.com/doc/current/service_container/autowiring.html) generally)
+are:
+- The type of the parameter. It needs to be `EntityRepositoryInterface`
+- The name of the variable. It must be the same as the id of the service in the DIC, written in `camelCase` instead of `snake_case`, followed by the word `Repository`.
+
+So for example, a media_thumbnail repository (id `media_thumbnail.repository`) would be requested (and injected) like this:
+```php
+public function __construct(EntityRepositoryInterface $mediaThumbnailRepository) {}
+```

--- a/src/Core/Framework/DependencyInjection/CompilerPass/EntityCompilerPass.php
+++ b/src/Core/Framework/DependencyInjection/CompilerPass/EntityCompilerPass.php
@@ -5,6 +5,7 @@ namespace Shopware\Core\Framework\DependencyInjection\CompilerPass;
 use Shopware\Core\Framework\DataAbstractionLayer\DefinitionInstanceRegistry;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityDefinition;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityRepositoryInterface;
 use Shopware\Core\Framework\DataAbstractionLayer\Read\EntityReaderInterface;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\EntityAggregatorInterface;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearcherInterface;
@@ -69,6 +70,7 @@ class EntityCompilerPass implements CompilerPassInterface
                 $repository->setPublic(true);
 
                 $container->setDefinition($repositoryId, $repository);
+                $container->registerAliasForArgument($repositoryId, EntityRepositoryInterface::class);
             }
             $repositoryNameMap[$entity] = $repositoryId;
         }

--- a/src/Core/Framework/Test/DependencyInjection/CompilerPass/EntityCompilerPassTest.php
+++ b/src/Core/Framework/Test/DependencyInjection/CompilerPass/EntityCompilerPassTest.php
@@ -1,0 +1,42 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\Test\DependencyInjection\CompilerPass;
+
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Checkout\Customer\Aggregate\CustomerAddress\CustomerAddressDefinition;
+use Shopware\Core\Checkout\Customer\CustomerDefinition;
+use Shopware\Core\Framework\DataAbstractionLayer\DefinitionInstanceRegistry;
+use Shopware\Core\Framework\DependencyInjection\CompilerPass\EntityCompilerPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+class EntityCompilerPassTest extends TestCase
+{
+    public function testEntityRepositoryAutowiring(): void
+    {
+        $container = new ContainerBuilder();
+
+        $container->register(CustomerAddressDefinition::class, CustomerAddressDefinition::class)
+            ->addTag('shopware.entity.definition');
+        $container->register(CustomerDefinition::class, CustomerDefinition::class)
+            ->addTag('shopware.entity.definition');
+
+        $container->register(DefinitionInstanceRegistry::class, DefinitionInstanceRegistry::class)
+            ->addArgument(new Reference('service_container'))
+            ->addArgument([
+                CustomerDefinition::ENTITY_NAME => CustomerDefinition::class,
+                CustomerAddressDefinition::ENTITY_NAME => CustomerAddressDefinition::class,
+            ])
+            ->addArgument([
+                CustomerDefinition::ENTITY_NAME => 'customer.repository',
+                CustomerAddressDefinition::ENTITY_NAME => 'customer_address.repository',
+            ]);
+
+        $entityCompilerPass = new EntityCompilerPass();
+        $entityCompilerPass->process($container);
+
+        // Make sure the correct aliases have been set
+        static::assertNotNull($container->getAlias('Shopware\Core\Framework\DataAbstractionLayer\EntityRepositoryInterface $customerRepository'));
+        static::assertNotNull($container->getAlias('Shopware\Core\Framework\DataAbstractionLayer\EntityRepositoryInterface $customerAddressRepository'));
+    }
+}

--- a/src/Docs/Resources/current/20-developer-guide/50-database.md
+++ b/src/Docs/Resources/current/20-developer-guide/50-database.md
@@ -40,7 +40,10 @@ public function __construct (EntityRepositoryInterface $productRepository)
 }
 ```
 
-Then, configure the `product.repository` service to be injected:
+If you're using [service autowiring](https://symfony.com/doc/current/service_container/autowiring.html), and the
+type and argument variable names are correct, the repository will be injected automatically.
+
+Alternatively, configure the `product.repository` service to be injected explicitly:
 
 ```xml
 <!-- SwagExamplePlugin/src/Resources/config/service.xml -->


### PR DESCRIPTION
### 1. What does this change do, exactly?
This change adds support for the Symfony DIC autowiring feature in combination with Shopware entity repositories.

### 2. Describe each step to reproduce the issue or behaviour.
Create a new service, configure it for being autowired and having the constructor signature `public function __construct(EntityRepositoryInterface $productRepository)`. Using this change, the new service will have the correct repository injected automatically.

### 3. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/master/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
