### PR TITLE
NEXT-9410 - Add target attribute to manufacturer link on product deta…

### DIFF
--- a/changelog/_unreleased/2020-09-17-open-manufacturer-links-in-new-tab.md
+++ b/changelog/_unreleased/2020-09-17-open-manufacturer-links-in-new-tab.md
@@ -1,0 +1,9 @@
+---
+title: Open manufacturer links in new tab
+issue: NEXT-9410
+author: Timo Helmke
+author_email: t.helmke@kellerkinder.de 
+author_github: @t2oh4e
+---
+# Storefront
+* Added a target attribute to manufacturer links in `src/Storefront/Resources/views/storefront/page/product-detail/headline.html.twig`

--- a/src/Storefront/Resources/views/storefront/page/product-detail/headline.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/product-detail/headline.html.twig
@@ -17,6 +17,7 @@
                     {% block page_product_detail_manufacturer_link %}
                         <a href="{{ page.product.manufacturer.link }}"
                            class="product-detail-manufacturer-link"
+                           target="_blank"
                            title="{{ page.product.manufacturer.translated.name }}">
                             {% if page.product.manufacturer.media %}
                                 {% block page_product_detail_manufacturer_logo %}


### PR DESCRIPTION
…il page. Fixes #15.

<!--
Thank you for contributing to the Shopware BoostDay! Please fill out this description template to help us to process your pull request.

Important! Please make sure your PRs follows the following structure:
-My commit(s) look like this "next-XXXX/my-commit-massage" (next-xxxx is found in the title of the issue)
-My title looks something like this "NEXT-XXXX - Issue name" (You can use the same Title as in the issue you're dealing with)

Please make sure to fulfil our general contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/contribution/contribution-guideline?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->


### 1. What does this change do, exactly?
Opens the link to the manufacturer page in a new tab.

### 2. Describe each step to reproduce the issue or behaviour.
Visit a product detail page with a manufacturer that has a website. Click on the link. Before this change it opens in the same tab and "closes" the shop. After the change it will be opened in a new tab. See: https://vimeo.com/458894191/b47607ba55

### 3. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/master/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
