### PR TITLE
NEXT-10848 - Pass all non-defined attributes as props in sw-button

### DIFF
--- a/changelog/_unreleased/2020-09-17-pass-all-non-defined-attributes-as-props-in-sw-button.md
+++ b/changelog/_unreleased/2020-09-17-pass-all-non-defined-attributes-as-props-in-sw-button.md
@@ -1,0 +1,9 @@
+---
+title:              Pass all non-defined attributes as props in sw-button
+issue:              NEXT-10848
+author:             Felix Brucker
+author_email:       felix@felixbrucker.com
+author_github:      @felixbrucker
+---
+# Administration
+* Changed the `sw-button` component to pass all non-defined attributes to its child elements (`router-link`, `a` and `button`) as props.

--- a/src/Administration/Resources/app/administration/src/app/component/base/sw-button/sw-button.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/base/sw-button/sw-button.html.twig
@@ -4,7 +4,8 @@
                      :to="routerLink"
                      class="sw-button"
                      :event="!disabled ? 'click' : ''"
-                     :class="buttonClasses">
+                     :class="buttonClasses"
+                     v-bind="$attrs">
             {% block sw_button_router_link_content %}
                 <span class="sw-button__content">
                     <slot>{% block sw_button_router_link_slot_default %}{% endblock %}</slot>
@@ -19,7 +20,8 @@
            target="_blank"
            rel="noopener"
            class="sw-button"
-           :class="buttonClasses">
+           :class="buttonClasses"
+           v-bind="$attrs">
             {% block sw_button_link_content %}
                 <span class="sw-button__content">
                     <slot>{% block sw_button_link_slot_default %}{% endblock %}</slot>
@@ -33,6 +35,7 @@
                 class="sw-button"
                 :class="buttonClasses"
                 :disabled="disabled || isLoading"
+                v-bind="$attrs"
                 v-on="$listeners">
             {% block sw_button_button_content %}
                 <sw-icon name="default-web-loading-circle"

--- a/src/Administration/Resources/app/administration/test/app/component/base/sw-button.spec.js
+++ b/src/Administration/Resources/app/administration/test/app/component/base/sw-button.spec.js
@@ -18,4 +18,47 @@ describe('components/base/sw-button', () => {
         expect(slot).toBeTruthy();
         expect(slot.text()).toBe(label);
     });
+
+    it('should render a plain button visible to screen readers', async () => {
+        const wrapper = shallowMount(Shopware.Component.build('sw-button'), {
+            slots: { default: 'Screen reader button text' },
+            propsData: { role: 'button' }
+        });
+        const slot = wrapper.find('.sw-button__content');
+        expect(slot).toBeTruthy();
+        expect(slot.text()).toBe('Screen reader button text');
+        const button = wrapper.find('button');
+        expect(button).toBeTruthy();
+        expect(button.attributes('role')).toBe('button');
+    });
+
+    it('should render a download button with a custom file name', async () => {
+        const wrapper = shallowMount(Shopware.Component.build('sw-button'), {
+            propsData: {
+                download: 'My filename.txt',
+                link: 'http://my.download.link'
+            }
+        });
+        const anchor = wrapper.find('a');
+        expect(anchor).toBeTruthy();
+        expect(anchor.attributes('href')).toBe('http://my.download.link');
+        expect(anchor.attributes('download')).toBe('My filename.txt');
+    });
+
+    it('should render a relative router-link button', async () => {
+        const wrapper = shallowMount(Shopware.Component.build('sw-button'), {
+            propsData: {
+                routerLink: { path: 'some/relative/link' },
+                append: true
+            },
+            slots: { default: 'Router-link text' },
+            stubs: ['router-link']
+        });
+        const routerLink = wrapper.find('router-link-stub');
+        expect(routerLink).toBeTruthy();
+        expect(routerLink.attributes('append')).toBe('true');
+        const slot = wrapper.find('.sw-button__content');
+        expect(slot).toBeTruthy();
+        expect(slot.text()).toBe('Router-link text');
+    });
 });


### PR DESCRIPTION
<!--
Thank you for contributing to the Shopware BoostDay! Please fill out this description template to help us to process your pull request.

Important! Please make sure your PRs follows the following structure:
-My commit(s) look like this "next-XXXX/my-commit-massage" (next-xxxx is found in the title of the issue)
-My title looks something like this "NEXT-XXXX - Issue name" (You can use the same Title as in the issue you're dealing with)

Please make sure to fulfil our general contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/contribution/contribution-guideline?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->


### 1. What does this change do, exactly?
This change will pass all non-defined attributes of the `sw-button` to its children (`router-link`, `a` and `button`) as props through the use of `v-bind="$attrs"`.

### 2. Describe each step to reproduce the issue or behaviour.
- Create eg. a link type button and add the `download` attribute, like so:
```html
<sw-button
        variant="primary"
        :link="downloadLink"
        :download="downloadFileName"
>
    my download button
</sw-button>
```
- Observe the download file name is not used, while with this change it is.
 
### 3. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/master/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
