### PR TITLE
NEXT-9166 - Fix long category names overflowing their boundaries

### DIFF
--- a/changelog/_unreleased/2020-09-17-fix-category-name-overflow.md
+++ b/changelog/_unreleased/2020-09-17-fix-category-name-overflow.md
@@ -1,0 +1,9 @@
+---
+title:              Fix category name overflow
+issue:              NEXT-9116
+author:             Daniel Huth
+author_email:       daniel.huth@pickware.de
+author_github:      @agreon
+---
+# Administration
+* Changed style `height` of `.sw-tree-item` and `.tree-item` to `100%` to prevent that category names overflow their boundaries. 

--- a/src/Administration/Resources/app/administration/src/app/component/tree/sw-tree-item/sw-tree-item.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/tree/sw-tree-item/sw-tree-item.scss
@@ -212,6 +212,8 @@ $sw-tree-item-color-text: $color-gutenberg;
             text-decoration: inherit;
             padding: 12px 0;
             display: block;
+            overflow: hidden;
+            text-overflow: ellipsis;
         }
     }
 

--- a/src/Administration/Resources/app/administration/src/app/component/tree/sw-tree/sw-tree.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/tree/sw-tree/sw-tree.scss
@@ -38,12 +38,12 @@
 
         .tree-items {
             padding: 16px 16px 0 16px;
-            width: max-content;
+            width: 100%;
             min-width: 100%;
         }
 
         .sw-tree-item {
-            width: max-content;
+            width: 100%;
             min-width: 100%;
         }
 


### PR DESCRIPTION
<!--
Thank you for contributing to the Shopware BoostDay! Please fill out this description template to help us to process your pull request.

Important! Please make sure your PRs follows the following structure:
-My commit(s) look like this "next-XXXX/my-commit-massage" (next-xxxx is found in the title of the issue)
-My title looks something like this "NEXT-XXXX - Issue name" (You can use the same Title as in the issue you're dealing with)

Please make sure to fulfil our general contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/contribution/contribution-guideline?category=shopware-platform-dev-en/contribution).

-->


### 1. What does this change do, exactly?

This PR fixes the category names to overflow if they are too long. 

View without the change:

![Screenshot from 2020-09-17 11-18-38](https://user-images.githubusercontent.com/4455258/93451689-cc738000-f8d7-11ea-9e71-3122dbb9a883.png)

View with the change:

![Screenshot from 2020-09-17 11-19-22](https://user-images.githubusercontent.com/4455258/93451705-d301f780-f8d7-11ea-90ef-498ccf0b792e.png)

The cause for the behaviour was the use of the [experimental](https://developer.mozilla.org/de/docs/Web/CSS/width) value `max-content` for the width of tree-items. 

### 2. Describe each step to reproduce the issue or behaviour.

Give a category a too long name and the context menu trigger will disappear.

### 3. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/master/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
