### PR TITLE
NEXT-9021 - Add autoscroll to listing

### DIFF
--- a/changelog/_unreleased/2020-09-17-add-autoscroll-to-listing.md
+++ b/changelog/_unreleased/2020-09-17-add-autoscroll-to-listing.md
@@ -1,0 +1,9 @@
+---
+title:              Add autoscroll to listing
+issue:              NEXT-9021
+author:             Sebastian König
+author_email:       s.koenig@tinect.de
+author_github:      @tinect
+---
+# Storefront
+*  Changed `listing.plugin.js` to scroll to top of listing when it is updating

--- a/src/Storefront/Resources/app/storefront/src/plugin/listing/listing.plugin.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/listing/listing.plugin.js
@@ -25,7 +25,11 @@ export default class ListingPlugin extends Plugin {
         loadingElementLoaderClass: 'has-element-loader',
         snippets: {
             resetAllButtonText: 'Reset all'
-        }
+        },
+        //if the window should be scrolled to top of to the listingWrapper element
+        scrollTopListingWrapper: true,
+        // how much px the scrolling should be offset
+        scrollOffset: 15
     };
 
     init() {
@@ -165,6 +169,23 @@ export default class ListingPlugin extends Plugin {
         query = querystring.stringify(mapped);
 
         this._updateHistory(query);
+
+        if (this.options.scrollTopListingWrapper) {
+            this._scrollTopOfListing();
+        }
+    }
+
+    _scrollTopOfListing() {
+        const elemRect = this._cmsProductListingWrapper.getBoundingClientRect();
+        if (elemRect.top >= 0) {
+            return;
+        }
+
+        const top = elemRect.top + window.scrollY - this.options.scrollOffset;
+        window.scrollTo({
+            top: top,
+            behavior: 'smooth'
+        });
     }
 
     _updateHistory(query) {

--- a/src/Storefront/Resources/app/storefront/test/plugin/listing/listing.plugin.test.js
+++ b/src/Storefront/Resources/app/storefront/test/plugin/listing/listing.plugin.test.js
@@ -154,4 +154,86 @@ describe('ListingPlugin tests', () => {
         expect(listingPlugin._registry).not.toContain(elementsOutsideDocument[1]);
         expect(listingPlugin._registry).not.toContain(elementsOutsideDocument[2]);
     });
+
+    test('should not autoscroll to top because we are at the top', () => {
+        const mockElement = document.createElement('div');
+        const cmsElementProductListingWrapper = document.createElement('div');
+        cmsElementProductListingWrapper.classList.add('cms-element-product-listing-wrapper');
+
+        document.body.append(cmsElementProductListingWrapper);
+
+        listingPlugin = new ListingPlugin(mockElement);
+
+        jest.spyOn(listingPlugin, '_scrollTopOfListing');
+        window.scrollTo = jest.fn();
+        window.scrollY = 0;
+
+        expect(listingPlugin._scrollTopOfListing).not.toHaveBeenCalled();
+
+        listingPlugin._buildRequest();
+
+        expect(listingPlugin._scrollTopOfListing).toHaveBeenCalled();
+
+        expect(window.scrollTo).not.toHaveBeenCalled();
+    });
+
+    test('should autoscroll to top with scrollOffset because we are not at the top', () => {
+        const mockElement = document.createElement('div');
+        const cmsElementProductListingWrapper = document.createElement('div');
+        cmsElementProductListingWrapper.classList.add('cms-element-product-listing-wrapper');
+
+        document.body.append(cmsElementProductListingWrapper);
+
+        listingPlugin = new ListingPlugin(mockElement);
+
+        jest.spyOn(listingPlugin, '_scrollTopOfListing');
+        window.scrollTo = jest.fn();
+        window.scrollY = 500;
+
+        listingPlugin._cmsProductListingWrapper.getBoundingClientRect = () => ({
+            top: -500
+        })
+
+        expect(listingPlugin._scrollTopOfListing).not.toHaveBeenCalled();
+
+        listingPlugin._buildRequest();
+
+        expect(listingPlugin._scrollTopOfListing).toHaveBeenCalled();
+
+        expect(window.scrollTo).toHaveBeenCalledWith({
+            "behavior": "smooth",
+            "top": listingPlugin.options.scrollOffset * -1
+        });
+    });
+
+    test('should autoscroll to top of cmsElementProductListingWrapper because we are not at the top', () => {
+        const distanceToTop = 250;
+
+        const mockElement = document.createElement('div');
+        const cmsElementProductListingWrapper = document.createElement('div');
+        cmsElementProductListingWrapper.classList.add('cms-element-product-listing-wrapper');
+
+        document.body.append(cmsElementProductListingWrapper);
+
+        listingPlugin = new ListingPlugin(mockElement);
+
+        jest.spyOn(listingPlugin, '_scrollTopOfListing');
+        window.scrollTo = jest.fn();
+        window.scrollY = 500;
+
+        listingPlugin._cmsProductListingWrapper.getBoundingClientRect = () => ({
+            top: -1 * distanceToTop
+        })
+
+        expect(listingPlugin._scrollTopOfListing).not.toHaveBeenCalled();
+
+        listingPlugin._buildRequest();
+
+        expect(listingPlugin._scrollTopOfListing).toHaveBeenCalled();
+
+        expect(window.scrollTo).toHaveBeenCalledWith({
+            "behavior": "smooth",
+            "top": distanceToTop - listingPlugin.options.scrollOffset
+        });
+    });
 });


### PR DESCRIPTION
### 1. What does this change do, exactly?
Add scroll-up in listing to get the user moved to the top of the loaded listing while they are switching pages on bottom navigation.

### 2. Describe each step to reproduce the issue or behaviour.
- change page of listing on the bottom navigation
- see user stucks on this position

### 3. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/master/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
