### PR TITLE
NEXT-10916 - Allow html characters in product name

### DIFF
--- a/changelog/_unreleased/2020-09-15-allow-html-characters-in-product-name.md
+++ b/changelog/_unreleased/2020-09-15-allow-html-characters-in-product-name.md
@@ -1,0 +1,10 @@
+---
+title:  Added support for HTML like characters in the product name
+issue:  NEXT-10916
+author:             Steffen Beisenherz
+author_email:       steffen.beisenherz@gmail.com
+author_github:      @Sironheart
+---
+
+# Core
+* Added the `AllowHtml` flag to be able to use HTML-like characters in a product name (for example '<' or '>')

--- a/src/Core/Content/Product/ProductDefinition.php
+++ b/src/Core/Content/Product/ProductDefinition.php
@@ -32,6 +32,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\ChildCountField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\ChildrenAssociationField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\DateTimeField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\FkField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\AllowHtml;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\CascadeDelete;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\Deprecated;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\Inherited;
@@ -167,7 +168,8 @@ class ProductDefinition extends EntityDefinition
             (new BoolField('custom_field_set_selection_active', 'customFieldSetSelectionActive'))->addFlags(new Inherited()),
 
             (new TranslatedField('metaDescription'))->addFlags(new Inherited()),
-            (new TranslatedField('name'))->addFlags(new Inherited(), new SearchRanking(SearchRanking::HIGH_SEARCH_RANKING)),
+            (new TranslatedField('name'))
+                ->addFlags(new Inherited(), new SearchRanking(SearchRanking::HIGH_SEARCH_RANKING), new AllowHtml()),
             (new TranslatedField('keywords'))->addFlags(new Inherited()),
             (new TranslatedField('description'))->addFlags(new Inherited()),
             (new TranslatedField('metaTitle'))->addFlags(new Inherited()),

--- a/src/Core/Content/Test/Product/Api/ProductApiTest.php
+++ b/src/Core/Content/Test/Product/Api/ProductApiTest.php
@@ -192,6 +192,39 @@ class ProductApiTest extends TestCase
         static::assertSame($description, $product['data']['description']);
     }
 
+    public function testSpecialCharacterInNameTest(): void
+    {
+        $id = Uuid::randomHex();
+
+        $name = 'naming < test';
+
+        $data = [
+            'id' => $id,
+            'productNumber' => Uuid::randomHex(),
+            'stock' => 1,
+            'name' => $name,
+            'price' => [['currencyId' => Defaults::CURRENCY, 'gross' => 15, 'net' => 10, 'linked' => false]],
+            'manufacturer' => ['name' => 'test'],
+            'tax' => ['name' => 'test', 'taxRate' => 15],
+        ];
+
+        $this->getBrowser()->request('POST', '/api/v' . PlatformRequest::API_VERSION . '/product', $data);
+        static::assertSame(Response::HTTP_NO_CONTENT, $this->getBrowser()->getResponse()->getStatusCode(), $this->getBrowser()->getResponse()->getContent());
+
+        $this->getBrowser()->request('GET', '/api/v' . PlatformRequest::API_VERSION . '/product/' . $id, [], [], [
+            'HTTP_ACCEPT' => 'application/json',
+        ]);
+
+        $response = $this->getBrowser()->getResponse();
+        static::assertSame(Response::HTTP_OK, $response->getStatusCode());
+
+        $product = json_decode($response->getContent(), true);
+
+        static::assertNotEmpty($product);
+        static::assertArrayHasKey('data', $product);
+        static::assertSame($name, $product['data']['name']);
+    }
+
     public function testIncludesWithJsonApi(): void
     {
         $ids = new TestDataCollection(Context::createDefaultContext());


### PR DESCRIPTION
# 1. What does this change do, exactly?
This allows the use of special characters like '<' or '>' which are common to HTML.
It does so by adding the `AllowHtml` Flag to the `ProductDefinition::name`

### 2. Describe each step to reproduce the issue or behaviour.
Create a product with a special character like '<' in the name. (for example use 'Ergonomic Co<pper')
Without my change everything after the special character will be removed
With my change the name field will be used as given before submiting the information

### 3. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/master/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
