### PR TITLE
NEXT-9023 - Fix ListingPage pagination arrows always visible #44

### DIFF
--- a/changelog/_unreleased/2020-09-17-fix-listingpage-pagination-arrows-always-visible.md
+++ b/changelog/_unreleased/2020-09-17-fix-listingpage-pagination-arrows-always-visible.md
@@ -1,0 +1,9 @@
+---
+title:          Hide unsupported arrows on pagination view
+issue:          NEXT-9023
+author:         Michał Jędraszczyk
+author_email:   m.jedrasz@gmail.com
+author_github:  @art4webs
+---
+# Storefront
+*  Hide prev arrows on first page and next arrows on last page in `pagination.html.twig`

--- a/changelog/_unreleased/2020-09-17-fix-listingpage-pagination-arrows-always-visible.md
+++ b/changelog/_unreleased/2020-09-17-fix-listingpage-pagination-arrows-always-visible.md
@@ -6,4 +6,4 @@ author_email:   m.jedrasz@gmail.com
 author_github:  @art4webs
 ---
 # Storefront
-*  Hide prev arrows on first page and next arrows on last page in `pagination.html.twig`
+*  Removed prev arrows on first page and next arrows on last page in `pagination.html.twig`

--- a/changelog/readme.md
+++ b/changelog/readme.md
@@ -3,6 +3,8 @@ For every feature or important code change there has to be a changelog markdown 
 {YYYY-MM-DD}-Meaningful-title-of-the-change.md  
 **Example**: 2020-08-03-New-CMS-components-for-3D-content.md
 
+For simplicity there is a console command which helps you to create new changelog files: `bin/console changelog:create [<title>] [options]`. For a full list of options just use the --help flag of the command.
+
 In the file all necessary changes are documented. The content of the file should always use the template which can be found in the `/changelog/_template.md` file. You can see a full example in the `/changelog/_example.md` file for a better understanding. 
 
 ## Meta Information

--- a/src/Storefront/Resources/views/storefront/component/pagination.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/pagination.html.twig
@@ -6,15 +6,15 @@
         {% block component_pagination %}
             <ul class="pagination">
                 {% block component_pagination_first %}
-                    <li class="page-item page-first{% if currentPage == 1 %} disabled{% endif %}">
+                    {% if currentPage > 1 %}
+                    <li class="page-item page-first">
                         {% block component_pagination_first_input %}
-                            <input type="radio"
-                                   {% if currentPage == 1 %}disabled="disabled"{% endif %}
-                                   name="p"
-                                   id="p-first"
-                                   value="1"
-                                   class="d-none"
-                                   title="pagination">
+                                <input type="radio"
+                                       name="p"
+                                       id="p-first"
+                                       value="1"
+                                       class="d-none"
+                                       title="pagination">
                         {% endblock %}
 
                         {% block component_pagination_first_label %}
@@ -25,13 +25,14 @@
                             </label>
                         {% endblock %}
                     </li>
+                    {% endif %}
                 {% endblock %}
 
                 {% block component_pagination_prev %}
-                    <li class="page-item page-prev{% if currentPage == 1 %} disabled{% endif %}">
+                    {% if currentPage > 1 %}
+                    <li class="page-item page-prev">
                         {% block component_pagination_prev_input %}
                             <input type="radio"
-                                   {% if currentPage == 1 %}disabled="disabled"{% endif %}
                                    name="p"
                                    id="p-prev"
                                    value="{{ currentPage - 1 }}"
@@ -49,6 +50,7 @@
                             </label>
                         {% endblock %}
                     </li>
+                    {% endif %}
                 {% endblock %}
 
                 {% block component_pagination_loop %}
@@ -99,10 +101,10 @@
                 {% endblock %}
 
                 {% block component_pagination_next %}
-                    <li class="page-item page-next{% if currentPage == totalPages %} disabled{% endif %}">
+                    {% if currentPage < totalPages %}
+                    <li class="page-item page-next">
                         {% block component_pagination_next_input %}
                             <input type="radio"
-                                   {% if currentPage == totalPages %}disabled="disabled"{% endif %}
                                    name="p"
                                    id="p-next"
                                    value="{{ currentPage + 1 }}"
@@ -120,13 +122,14 @@
                             </label>
                         {% endblock %}
                     </li>
+                    {% endif %}
                 {% endblock %}
 
                 {% block component_pagination_last %}
-                    <li class="page-item page-last{% if currentPage == totalPages %} disabled{% endif %}">
+                    {% if currentPage < totalPages %}
+                    <li class="page-item page-last">
                         {% block component_pagination_last_input %}
                             <input type="radio"
-                                   {% if currentPage == totalPages %}disabled="disabled"{% endif %}
                                    name="p"
                                    id="p-last"
                                    value="{{ totalPages }}"
@@ -147,6 +150,7 @@
                             </label>
                         {% endblock %}
                     </li>
+                    {% endif %}
                 {% endblock %}
             </ul>
         {% endblock %}


### PR DESCRIPTION
1. What does this change do, exactly?
Hide prev arrows on first page and next arrows on last page in `pagination.html.twig`

2. Describe each step to reproduce the issue or behaviour.
Go to first page on homepage list
Got to last page on homepage list