### PR TITLE
NEXT-7962 - Add label to shipping method detail fixes #73

### DIFF
--- a/changelog/_unreleased/2020-09-17-add-label-to-availabitlity-rule-in-shipping-method-detail.md
+++ b/changelog/_unreleased/2020-09-17-add-label-to-availabitlity-rule-in-shipping-method-detail.md
@@ -1,0 +1,24 @@
+---
+title: Add label to availabitlity rule in shipping method detail
+issue: 7962
+author: Muehlhans Florian
+author_email: muehlhans.f@idowapro.de 
+author_github: muehlhansf
+---
+# Core
+*  
+___
+# API
+*  
+___
+# Administration
+*  
+___
+# Storefront
+*  Added new label availability Rule to `sw-settings-shipment-detail/index.js`
+___
+# Upgrade Information
+## Topic 1
+### Topic 1a
+### Topic 1b
+## Topic 2

--- a/changelog/_unreleased/2020-09-17-add-label-to-availabitlity-rule-in-shipping-method-detail.md
+++ b/changelog/_unreleased/2020-09-17-add-label-to-availabitlity-rule-in-shipping-method-detail.md
@@ -6,4 +6,4 @@ author_email: muehlhans.f@idowapro.de
 author_github: @muehlhansf
 ---
 # Administration
-* Added new label availability rule to `sw-settings-shipment-detail`
+* Added new label to availability rule selection in `sw-settings-shipment-detail`

--- a/changelog/_unreleased/2020-09-17-add-label-to-availabitlity-rule-in-shipping-method-detail.md
+++ b/changelog/_unreleased/2020-09-17-add-label-to-availabitlity-rule-in-shipping-method-detail.md
@@ -1,24 +1,9 @@
 ---
 title: Add label to availabitlity rule in shipping method detail
-issue: 7962
+issue: NEXT-7962
 author: Muehlhans Florian
 author_email: muehlhans.f@idowapro.de 
-author_github: muehlhansf
+author_github: @muehlhansf
 ---
-# Core
-*  
-___
-# API
-*  
-___
 # Administration
-*  
-___
-# Storefront
-*  Added new label availability Rule to `sw-settings-shipment-detail/index.js`
-___
-# Upgrade Information
-## Topic 1
-### Topic 1a
-### Topic 1b
-## Topic 2
+* Added new label availability rule to `sw-settings-shipment-detail`

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-shipping/page/sw-settings-shipping-detail/sw-settings-shipping-detail.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-shipping/page/sw-settings-shipping-detail/sw-settings-shipping-detail.html.twig
@@ -148,6 +148,7 @@
                                                        :ruleFilter="ruleFilter"
                                                        :disabled="!acl.can('shipping.editor')"
                                                        required
+                                                       :label="$tc('sw-settings-shipping.detail.topRule')"
                                                        class="sw-settings-shipping-detail__top-rule"
                                                        @save-rule="onSaveRule">
                                 </sw-select-rule-create>


### PR DESCRIPTION
this time with changelog

<!--
Thank you for contributing to the Shopware BoostDay! Please fill out this description template to help us to process your pull request.

Important! Please make sure your PRs follows the following structure:
-My commit(s) look like this "next-XXXX/my-commit-massage" (next-xxxx is found in the title of the issue)
-My title looks something like this "NEXT-XXXX - Issue name" (You can use the same Title as in the issue you're dealing with)

Please make sure to fulfil our general contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/contribution/contribution-guideline?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->


### 1. What does this change do, exactly?
Adds a label to shipping method detail/create page, to show user that the availabitlity rule input field is required.
it uses a already existing translation.

### 2. Describe each step to reproduce the issue or behaviour.
create shipping method without setting a availability rule or try to update a existing shipment without setting the availability rule

### 3. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [X ] I have created a [changelog file](https://github.com/shopware/platform/blob/master/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.
