### PR TITLE
NEXT-8145 - minify compiled CSS fixes #65

### DIFF
--- a/changelog/_unreleased/2020-09-17-minify-css.md
+++ b/changelog/_unreleased/2020-09-17-minify-css.md
@@ -1,0 +1,10 @@
+---
+title: Minify CSS
+issue: NEXT-8145
+author: Max
+author_email: max@swk-web.com
+author_github: @aragon999
+---
+# Storefront
+*  Added `\Shopware\Storefront\Theme\Autoprefixer` with the ability to minify compiled css
+*  Changed the behaviour of the autoprefixer to minify the compiled CSS

--- a/src/Storefront/Theme/Autoprefixer.php
+++ b/src/Storefront/Theme/Autoprefixer.php
@@ -1,0 +1,48 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Storefront\Theme;
+
+use Padaliyajay\PHPAutoprefixer\Autoprefixer as PadaliyajayAutoprefixer;
+use Sabberworm\CSS\OutputFormat;
+use Sabberworm\CSS\Parser;
+
+/*
+ * This class implements a pull request of the core autoprefixer, to enable
+ * minification of the compiled CSS, if the update is released this
+ * class should be removed and Padaliyajay\PHPAutoprefixer\Autoprefixer should
+ * be used instead, see:
+ * https://github.com/padaliyajay/php-autoprefixer/pull/8
+ * https://github.com/padaliyajay/php-autoprefixer/issues/10
+ */
+class Autoprefixer extends PadaliyajayAutoprefixer
+{
+    /**
+     * @var Parser
+     */
+    private $cssParser;
+
+    public function __construct(string $cssCode)
+    {
+        $this->cssParser = new Parser($cssCode);
+    }
+
+    /**
+     * @return string|bool
+     */
+    public function compile(bool $prettyOutput = true)
+    {
+        if ($this->cssParser) {
+            $cssDocument = $this->cssParser->parse();
+
+            $this->compileCSSList($cssDocument);
+
+            $outputFormat = $prettyOutput
+                ? OutputFormat::createPretty()
+                : OutputFormat::createCompact();
+
+            return $cssDocument->render($outputFormat);
+        }
+
+        return false;
+    }
+}

--- a/src/Storefront/Theme/ThemeCompiler.php
+++ b/src/Storefront/Theme/ThemeCompiler.php
@@ -69,6 +69,11 @@ class ThemeCompiler implements ThemeCompilerInterface
      */
     private $cacheClearer;
 
+    /**
+     * @var bool
+     */
+    private $debug;
+
     public function __construct(
         FilesystemInterface $filesystem,
         FilesystemInterface $tempFilesystem,
@@ -93,6 +98,8 @@ class ThemeCompiler implements ThemeCompilerInterface
         $this->mediaRepository = $mediaRepository;
         $this->packages = $packages;
         $this->cacheClearer = $cacheClearer;
+
+        $this->debug = $debug;
     }
 
     public function compileTheme(
@@ -214,7 +221,7 @@ class ThemeCompiler implements ThemeCompilerInterface
         }
         $autoPreFixer = new Autoprefixer($cssOutput);
 
-        return $autoPreFixer->compile(false);
+        return $autoPreFixer->compile($this->debug);
     }
 
     private function formatVariables(array $variables): array

--- a/src/Storefront/Theme/ThemeCompiler.php
+++ b/src/Storefront/Theme/ThemeCompiler.php
@@ -3,7 +3,6 @@
 namespace Shopware\Storefront\Theme;
 
 use League\Flysystem\FilesystemInterface;
-use Padaliyajay\PHPAutoprefixer\Autoprefixer;
 use ScssPhp\ScssPhp\Compiler;
 use ScssPhp\ScssPhp\Formatter\Crunched;
 use ScssPhp\ScssPhp\Formatter\Expanded;
@@ -215,7 +214,7 @@ class ThemeCompiler implements ThemeCompilerInterface
         }
         $autoPreFixer = new Autoprefixer($cssOutput);
 
-        return $autoPreFixer->compile();
+        return $autoPreFixer->compile(false);
     }
 
     private function formatVariables(array $variables): array


### PR DESCRIPTION
### 1. Why is this change necessary?
Currently the CSS gets "deminified" by the autoprefixer, but there is currently no way to circumvent this, see:
https://github.com/padaliyajay/php-autoprefixer/pull/8
https://github.com/padaliyajay/php-autoprefixer/issues/10

### 2. What does this change do, exactly?
"Manually" minify the CSS in the CSS compiler.

### 3. Describe each step to reproduce the issue or behaviour.
Look at the compiled CSS with and without this PR.

### 4. Please link to the relevant issues (if any).
Fixes #65 

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/master/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
