### PR TITLE
NEXT-9292 Fix bug for product image positions to normalize sorting an…

### DIFF
--- a/changelog/_unreleased/2020-09-17-fix-product-media-position-duplication.md
+++ b/changelog/_unreleased/2020-09-17-fix-product-media-position-duplication.md
@@ -1,0 +1,34 @@
+---
+title:         Fix bug when images are added to a product, the position 1 can be assigned multiple times
+issue:         NEXT-9292
+author:        Joshua Behrens
+author_email:  code@joshua-behrens.de
+author_github: JoshuaBehrens
+---
+# Administration
+* Changed procedure to assign `product_media.position` in `sw-product-media-form` and `sw-product-detail` so it is always set to prevent a bug where the position 1 is automatically assigned which results in unexpected sorting and selection behaviours
+___
+# Upgrade Information
+
+## Am I affected of this bug?
+
+To check whether you are affected of this position bug you can use the following SQL to check your product images for this bug.
+With this information you can fix the order accordingly using the drag and drop functionality in the administration:
+```sql
+SELECT
+    LOWER(HEX(product_id)) product_id,
+    GROUP_CONCAT(DISTINCT product_number, ';') product_number,
+    position,
+    COUNT(1) ducplicates
+FROM
+    product_media
+LEFT JOIN
+    product
+ON
+    product_media.product_id = product.id AND product_media.product_version_id = product.version_id
+GROUP BY
+    product_id,
+    position
+HAVING
+    ducplicates > 1
+```

--- a/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-media-form/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-media-form/index.js
@@ -184,13 +184,13 @@ Component.register('sw-product-media-form', {
 
             productMedia.productId = this.product.id;
             productMedia.mediaId = targetId;
+            productMedia.position = this.product.media.length;
 
-            if (this.product.media.length <= 0) {
-                productMedia.position = 0;
+            if (productMedia.position === 0) {
                 this.product.coverId = productMedia.id;
-            } else {
-                productMedia.position = this.product.media.length;
+                this.product.cover = productMedia;
             }
+
             return productMedia;
         },
 
@@ -245,15 +245,7 @@ Component.register('sw-product-media-form', {
                 return;
             }
 
-            const productMedia = this.createMediaAssociation(dragData.mediaItem.id);
-            if (this.product.media.length === 0) {
-                // set media item as cover
-                productMedia.position = 0;
-                this.product.cover = productMedia;
-                this.product.coverId = productMedia.id;
-            }
-
-            this.product.media.add(productMedia);
+            this.product.media.add(this.createMediaAssociation(dragData.mediaItem.id));
         },
 
         onMediaItemDragSort(dragData, dropData, validDrop) {

--- a/src/Administration/Resources/app/administration/src/module/sw-product/page/sw-product-detail/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/page/sw-product-detail/index.js
@@ -565,16 +565,14 @@ Component.register('sw-product-detail', {
 
             const newMedia = this.mediaRepository.create(Shopware.Context.api);
             newMedia.mediaId = mediaItem.id;
+            newMedia.position = this.product.media.length;
 
             return new Promise((resolve) => {
-                // if no other media exists
-                if (this.product.media.length === 0) {
-                    // set media item as cover
-                    newMedia.position = 0;
+                if (newMedia.position === 0) {
                     this.product.coverId = newMedia.id;
                 }
-                this.product.media.add(newMedia);
 
+                this.product.media.add(newMedia);
                 Shopware.State.commit('swProductDetail/setLoading', ['media', false]);
 
                 resolve(newMedia.mediaId);


### PR DESCRIPTION
### 1. Why is this change necessary?
When you add a product with multiple images via sidebar the images that are not the first don't get a position assigned. When no position is assigned along the way for the data to the database only the database default value acts here and sets it to 1. When you now have duplicate positions sortings and galleries behave unexpected.

### 2. What does this change do, exactly?
It uses now the same procedure to set the position for a product_media entity in the administration.
At one point I noticed the cover is set twice and I leveled this as well.

### 3. Describe each step to reproduce the issue or behaviour.
1. Create/edit product
2. Add at least three images via sidebar
3. Save
4. Look into database or in the storefront

### 4. Please link to the relevant issues.
NEXT-9292

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/master/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
