### PR TITLE
NEXT-7416 - Prevent double submit in checkout

### DIFF
--- a/changelog/_unreleased/2020-09-17-prevent-double-submit-in-checkout.md
+++ b/changelog/_unreleased/2020-09-17-prevent-double-submit-in-checkout.md
@@ -1,0 +1,12 @@
+---
+title: Prevent double submit in checkout
+issue: NEXT-7416
+author: Claudio Bianco
+author_email: info@claudio-bianco.de
+author_github: @claudiobianco
+---
+# Core
+* Catch `EmptyCartException` when submitting order with empty cart (e.g. due to double click submit button)
+___
+# Storefront
+* Changed checkout order button to use `FormSubmitLoader` to prevent submitting it multiple times

--- a/src/Storefront/Controller/CheckoutController.php
+++ b/src/Storefront/Controller/CheckoutController.php
@@ -7,6 +7,7 @@ use Shopware\Core\Checkout\Cart\Exception\CartTokenNotFoundException;
 use Shopware\Core\Checkout\Cart\Exception\CustomerNotLoggedInException;
 use Shopware\Core\Checkout\Cart\Exception\OrderNotFoundException;
 use Shopware\Core\Checkout\Cart\SalesChannel\CartService;
+use Shopware\Core\Checkout\Order\Exception\EmptyCartException;
 use Shopware\Core\Checkout\Order\SalesChannel\OrderService;
 use Shopware\Core\Checkout\Payment\Exception\InvalidOrderException;
 use Shopware\Core\Checkout\Payment\Exception\PaymentProcessException;
@@ -172,6 +173,7 @@ class CheckoutController extends StorefrontController
             return $response ?? new RedirectResponse($finishUrl);
         } catch (ConstraintViolationException $formViolations) {
         } catch (Error $blockedError) {
+        } catch (EmptyCartException $blockedError) {
         } catch (PaymentProcessException | InvalidOrderException | UnknownPaymentMethodException $e) {
             return $this->forwardToRoute('frontend.checkout.finish.page', ['orderId' => $orderId, 'changedPayment' => false, 'paymentFailed' => true]);
         }

--- a/src/Storefront/Resources/app/storefront/test/plugin/forms/form-submit-loader.plugin.template.html
+++ b/src/Storefront/Resources/app/storefront/test/plugin/forms/form-submit-loader.plugin.template.html
@@ -1,0 +1,9 @@
+<div>
+    <button type="submit" id="nonForm">Not part of the form</button>
+
+    <form id="test"
+          data-form-submit-loader="true"
+          data-form-submit-loader-options="{&quot;disableAfterSubmit&quot;: true}">
+        <button type="submit" id="formBtn">Part of the form</button>
+    </form>
+</div>

--- a/src/Storefront/Resources/app/storefront/test/plugin/forms/form-submit-loader.plugin.test.js
+++ b/src/Storefront/Resources/app/storefront/test/plugin/forms/form-submit-loader.plugin.test.js
@@ -1,0 +1,57 @@
+/**
+ * @jest-environment jsdom
+ */
+
+/* eslint-disable */
+import Storage from 'src/helper/storage/storage.helper';
+import template from './form-submit-loader.plugin.template.html';
+import FormSubmitLoader from "../../../src/plugin/forms/form-submit-loader.plugin";
+
+describe('Form submit loader tests', () => {
+    let formSubmitLoaderPlugin = undefined;
+    let form = undefined;
+
+    beforeEach(() => {
+        document.body.innerHTML = template;
+
+        window.PluginManager = {
+            getPluginInstancesFromElement: () => {
+                return new Map();
+            },
+            getPlugin: () => {
+                return {
+                    get: () => []
+                };
+            }
+        };
+
+        Storage.clear();
+        form = document.querySelector('#test');
+        formSubmitLoaderPlugin = new FormSubmitLoader(form, null, 'FormSubmitLoader');
+    });
+
+    afterEach(() => {
+        formSubmitLoaderPlugin = undefined;
+    });
+
+    test('form submit loader plugin exists', () => {
+        expect(typeof formSubmitLoaderPlugin).toBe('object');
+    });
+
+    test('form is the sames as passed from', () => {
+        expect(formSubmitLoaderPlugin._form).toBe(form);
+    });
+
+    test('find correct submit button', () => {
+        const submitButton = document.querySelector('#formBtn');
+        expect(formSubmitLoaderPlugin._submitButton).toBe(submitButton);
+    });
+
+    test('submit button is disabled on submit', () => {
+        let event = new Event('submit');
+        formSubmitLoaderPlugin._onFormSubmit(event);
+
+        const submitButton = document.querySelector('#formBtn');
+        expect(submitButton.disabled).toBe(true);
+    });
+});

--- a/src/Storefront/Resources/views/storefront/page/checkout/confirm/index.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/checkout/confirm/index.html.twig
@@ -183,6 +183,7 @@
               action="{{ path('frontend.checkout.finish.order') }}"
               data-form-csrf-handler="true"
               data-form-preserver="true"
+              data-form-submit-loader="true"
               method="post">
 
             {% block page_checkout_aside_actions_csrf %}


### PR DESCRIPTION
Fixes shopwareBoostDay/platform#82

<!--
Thank you for contributing to the Shopware BoostDay! Please fill out this description template to help us to process your pull request.

Important! Please make sure your PRs follows the following structure:
-My commit(s) look like this "next-XXXX/my-commit-massage" (next-xxxx is found in the title of the issue)
-My title looks something like this "NEXT-XXXX - Issue name" (You can use the same Title as in the issue you're dealing with)

Please make sure to fulfil our general contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/contribution/contribution-guideline?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->


### 1. What does this change do, exactly?
Changes checkout order button to use `FormSubmitLoader` to prevent submitting it multiple times

### 2. Describe each step to reproduce the issue or behaviour.
Double click on "Send order" in checkout.

### 3. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/master/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
