### PR TITLE
NEXT-10928 - Optimise requests in `LocaleToLanguageService`

### DIFF
--- a/changelog/_unreleased/2020-09-17-optimise-requests-in-localetolanguageservice.md
+++ b/changelog/_unreleased/2020-09-17-optimise-requests-in-localetolanguageservice.md
@@ -1,0 +1,9 @@
+---
+title:              Optimise requests in LocaleToLanguageService
+issue:              NEXT-10928
+author:             Hannes Wernery
+author_email:       hannes.wernery@pickware.de
+author_github:      @hanneswernery
+---
+# Administration
+* Changes the requests in `LocaleToLanguageService` so send a single request when calling `localeToLanguage()`.

--- a/src/Administration/Resources/app/administration/src/app/service/locale-to-language.service.js
+++ b/src/Administration/Resources/app/administration/src/app/service/locale-to-language.service.js
@@ -13,25 +13,15 @@ export default function createLocaleToLanguageService() {
         const apiContext = Shopware.Context.api;
         const repoFactory = Shopware.Service('repositoryFactory');
         const localeRepo = repoFactory.create('locale', '/locale');
-        const languageRepo = repoFactory.create('language', '/language');
         const localeCriteria = new Criteria();
 
-        localeCriteria.addFilter(Criteria.equals('code', locale));
+        localeCriteria
+            .addFilter(Criteria.equals('code', locale))
+            .addAssociation('languages');
 
         return localeRepo.search(localeCriteria, apiContext)
             .then((data) => {
-                return data.first().id;
-            })
-            .then((id) => {
-                const languageCriteria = new Criteria();
-                languageCriteria.addFilter(
-                    Criteria.equals('language.localeId', id)
-                );
-
-                return languageRepo.search(languageCriteria, apiContext);
-            })
-            .then((languageData) => {
-                return languageData.first().id;
+                return data.first().languages.first().id;
             })
             .catch(() => {
                 // Fallback: System default language


### PR DESCRIPTION
<!--
Thank you for contributing to the Shopware BoostDay! Please fill out this description template to help us to process your pull request.

Important! Please make sure your PRs follows the following structure:
-My commit(s) look like this "next-XXXX/my-commit-massage" (next-xxxx is found in the title of the issue)
-My title looks something like this "NEXT-XXXX - Issue name" (You can use the same Title as in the issue you're dealing with)

Please make sure to fulfil our general contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/contribution/contribution-guideline?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->


### 1. What does this change do, exactly?

The `LocaleToLanguageService` uses two separate requests in its `localeToLanguage` function which is called at least **twice** upon opening the administration. Since these entities are associated with one another, this function can be optimised by using a single request with the respective association. This PR achieves this by improving the (single) request.

Before (notice the `language` requests):
<img width="711" alt="Screenshot 2020-09-17 at 13 45 57" src="https://user-images.githubusercontent.com/12038224/93466992-65f95c80-f8ed-11ea-8448-6d96eb98707e.png">

After (two requests less):
<img width="708" alt="Screenshot 2020-09-17 at 13 45 38" src="https://user-images.githubusercontent.com/12038224/93467039-77daff80-f8ed-11ea-8792-16357fa417c7.png">


### 2. Describe each step to reproduce the issue or behaviour.

Open the administration. Look into the browser-dev-tools network tab.


### 3. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/master/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
