### PR TITLE
Directly open product on search by number

### DIFF
--- a/src/Storefront/Controller/SearchController.php
+++ b/src/Storefront/Controller/SearchController.php
@@ -6,6 +6,7 @@ use Shopware\Core\Framework\Routing\Annotation\RouteScope;
 use Shopware\Core\Framework\Routing\Exception\MissingRequestParameterException;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Storefront\Framework\Cache\Annotation\HttpCache;
+use Shopware\Storefront\Page\Product\ProductPageLoader;
 use Shopware\Storefront\Page\Search\SearchPageLoader;
 use Shopware\Storefront\Page\Suggest\SuggestPageLoader;
 use Symfony\Component\HttpFoundation\Request;
@@ -41,6 +42,13 @@ class SearchController extends StorefrontController
     {
         try {
             $page = $this->searchPageLoader->load($request, $context);
+            if($page->getListing()->getTotal() == 1)
+            {
+                $elements = $page->getListing()->getElements();
+                $product = array_pop($elements);
+                $productId = $product->getId();
+                return $this->forwardToRoute('frontend.detail.page', [], ['productId' => $productId]);
+            }
         } catch (MissingRequestParameterException $missingRequestParameterException) {
             return $this->forwardToRoute('frontend.home.page');
         }


### PR DESCRIPTION
## 1. Why is this change necessary?
Like in SW5, there should be an option to be redirected directly from search to product details when search gives only one result and/or search query is exact match fro the product number (and/or possibly some other fields like ean or manufacturer number).

### 2. What does this change do, exactly?
It redirects from the listing page to the detail page when the searchPageLoader page only has got one result.

### 3. Describe each step to reproduce the issue or behaviour.
- Go to storefront
- Type an exactly article number to the search field and press enter

### 4. Please link to the relevant issues (if any).
https://github.com/shopwareBoostDay/platform/issues/116

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/master/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
