### PR TITLE
NEXT-9202 - Add keyboard shortcuts for reviews

### DIFF
--- a/changelog/_unreleased/2020-09-17-add-keyboard-shortcuts-for-reviews.md
+++ b/changelog/_unreleased/2020-09-17-add-keyboard-shortcuts-for-reviews.md
@@ -1,0 +1,9 @@
+---
+title: Add keyboard shortcuts for reviews
+issue: NEXT-9202
+author: Max
+author_email: max@swk-web.com
+author_github: @aragon999
+---
+# Administration
+*  Added review keyboard shortcuts to save and cancel the currently selected review

--- a/src/Administration/Resources/app/administration/src/module/sw-review/page/sw-review-detail/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-review/page/sw-review-detail/index.js
@@ -15,6 +15,16 @@ Component.register('sw-review-detail', {
         'salutation'
     ],
 
+    shortcuts: {
+        'SYSTEMKEY+S': {
+            active() {
+                return this.acl.can('review.editor');
+            },
+            method: 'onSave'
+        },
+        ESCAPE: 'onCancel'
+    },
+
     data() {
         return {
             isLoading: null,
@@ -62,6 +72,30 @@ Component.register('sw-review-detail', {
             criteria.addSorting(Criteria.sort('name', 'ASC', false));
 
             return criteria;
+        },
+
+        tooltipSave() {
+            if (!this.acl.can('review.editor')) {
+                return {
+                    message: this.$tc('sw-privileges.tooltip.warning'),
+                    disabled: true,
+                    showOnDisabledElements: true
+                };
+            }
+
+            const systemKey = this.$device.getSystemKey();
+
+            return {
+                message: `${systemKey} + S`,
+                appearance: 'light'
+            };
+        },
+
+        tooltipCancel() {
+            return {
+                message: 'ESC',
+                appearance: 'light'
+            };
         }
     },
 
@@ -116,6 +150,10 @@ Component.register('sw-review-detail', {
 
         onSaveFinish() {
             this.isSaveSuccessful = false;
+        },
+
+        onCancel() {
+            this.$router.push({ name: 'sw.review.index' });
         }
     }
 });

--- a/src/Administration/Resources/app/administration/src/module/sw-review/page/sw-review-detail/sw-review-detail.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-review/page/sw-review-detail/sw-review-detail.html.twig
@@ -11,21 +11,17 @@
             <template slot="smart-bar-actions">
 
                 {% block sw_review_detail_actions_abort %}
-                    <sw-button :disabled="isLoading" :routerLink="{ name: 'sw.review.index' }">
+                    <sw-button :disabled="isLoading" v-tooltip.bottom="tooltipCancel" @click="onCancel">
                         {{ $tc('global.default.cancel') }}
                     </sw-button>
                 {% endblock %}
 
                 {% block sw_review_detail_actions_save %}
                     <sw-button-process
-                            v-tooltip="{
-                                message: $tc('sw-privileges.tooltip.warning'),
-                                disabled: acl.can('review.editor'),
-                                showOnDisabledElements: true
-                            }"
                             class="sw-review-detail__save-action"
                             variant="primary"
                             :disabled="isLoading || !acl.can('review.editor')"
+                            v-tooltip.bottom="tooltipSave"
                             :processSuccess="isSaveSuccessful"
                             @process-finish="onSaveFinish"
                             @click="onSave">


### PR DESCRIPTION
### 1. Why is this change necessary?
Currently it is not possible to use the keyboard shortcuts for the reviews, to save and cancel the currently selected review.

### 2. What does this change do, exactly?
Add the keyboard shortcuts.

### 3. Describe each step to reproduce the issue or behaviour.
Open a review in the administration and press `ALT + S` (on my machine).

### 4. Please link to the relevant issues (if any).
Fixes #32

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/master/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
