### PR TITLE
NEXT-10857 - Directly open product on search by product number

### DIFF
--- a/changelog/_unreleased/2020-09-17-directly-open-product-on-search-by-product-number.md
+++ b/changelog/_unreleased/2020-09-17-directly-open-product-on-search-by-product-number.md
@@ -1,0 +1,9 @@
+---
+title: Directly open product on search if there is only one result
+issue: NEXT-10857
+author: Stefan Wild
+author_email: stefan.wild@sewisoft.de 
+author_github: @wildi1
+---
+# Storefront
+* Changed `\Shopware\Storefront\Controller\SearchController.php` to redirect direct to the detail page if there is only one result

--- a/src/Storefront/Controller/SearchController.php
+++ b/src/Storefront/Controller/SearchController.php
@@ -41,6 +41,14 @@ class SearchController extends StorefrontController
     {
         try {
             $page = $this->searchPageLoader->load($request, $context);
+            if ($page->getListing()->getTotal() === 1) {
+                $product = $page->getListing()->first();
+                if ($request->get('search') === $product->getProductNumber()) {
+                    $productId = $product->getId();
+
+                    return $this->forwardToRoute('frontend.detail.page', [], ['productId' => $productId]);
+                }
+            }
         } catch (MissingRequestParameterException $missingRequestParameterException) {
             return $this->forwardToRoute('frontend.home.page');
         }


### PR DESCRIPTION
## 1. Why is this change necessary?
Like in SW5, there should be an option to be redirected directly from search to product details when search gives only one result and/or search query is exact match fro the product number (and/or possibly some other fields like ean or manufacturer number).

### 2. What does this change do, exactly?
It redirects from the listing page to the detail page when the searchPageLoader page only has got one result.

### 3. Describe each step to reproduce the issue or behaviour.
- Go to storefront
- Type an exactly article number to the search field and press enter

### 4. Please link to the relevant issues (if any).
https://github.com/shopwareBoostDay/platform/issues/116

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/master/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
