### PR TITLE
NEXT-7986 #71 fixed thumbnails for the cms images. Used the default t…

### DIFF
--- a/changelog/_unreleased/2020-09-17-fix-thumbnails-for-cms-images.md
+++ b/changelog/_unreleased/2020-09-17-fix-thumbnails-for-cms-images.md
@@ -1,0 +1,9 @@
+---
+title: Fixed thumbnails for cms image block
+issue: NEXT-7986
+author: Colin Murphy
+author_email: colin@studioforty9.com
+author_github: colinmurphy
+---
+# Core
+*  Changed  the template `src/Storefront/Resources/views/storefront/element/cms-element-image.html.twig` to include sizes based off the default sizes set for the CMS media folder.

--- a/changelog/_unreleased/2020-09-17-fix-thumbnails-for-cms-images.md
+++ b/changelog/_unreleased/2020-09-17-fix-thumbnails-for-cms-images.md
@@ -6,4 +6,4 @@ author_email: colin@studioforty9.com
 author_github: colinmurphy
 ---
 # Core
-*  Changed  the template `src/Storefront/Resources/views/storefront/element/cms-element-image.html.twig` to include sizes based off the default sizes set for the CMS media folder.
+* Changed the template `src/Storefront/Resources/views/storefront/element/cms-element-image.html.twig` to include sizes based off the default sizes set for the CMS media folder.

--- a/src/Storefront/Resources/views/storefront/element/cms-element-image.html.twig
+++ b/src/Storefront/Resources/views/storefront/element/cms-element-image.html.twig
@@ -24,7 +24,12 @@
                                         {% endif %}
 
                                         {% sw_thumbnails 'cms-image-thumbnails' with {
-                                            media: element.data.media
+                                            media: element.data.media,
+                                            'xs': '400px',
+                                            'sm': '400px',
+                                            'md': '800px',
+                                            'lg': '1920px',
+                                            'xl': '1920px'
                                         } %}
                                     {% endblock %}
                                 </div>


### PR DESCRIPTION
…humbnail sizes from the media cms folder settings

<!--
Thank you for contributing to the Shopware BoostDay! Please fill out this description template to help us to process your pull request.

Important! Please make sure your PRs follows the following structure:
-My commit(s) look like this "next-XXXX/my-commit-massage" (next-xxxx is found in the title of the issue)
-My title looks something like this "NEXT-XXXX - Issue name" (You can use the same Title as in the issue you're dealing with)

Please make sure to fulfil our general contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/contribution/contribution-guideline?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->


### 1. What does this change do, exactly?

It fixes a bug with the cms image block to show thumbnails based off the thumbnail sizes set for the CMS media folder.


### 2. Describe each step to reproduce the issue or behaviour.

1. Create a Shopping Experience
2. Add a image block "image full-sized"
3. Upload an image (preferably above 1920px by 1920px in size)
4. Set the display setting for that block as cover
5. Save Shopping Experience
6. Associate that Shopping Experience with a category
7. When you visit the category page on mobile, the 400px thumbnail image will be loaded
8. When you visit the category page on tablet landscape, the 800px thumbnail image will be loaded
9. When you visit the category page on desktop (below 1920px in width), the 1920px thumbnail image will be loade


### 3. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/master/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
