### PR TITLE
NEXT-9304 Add option to make theme configuration field full width for…

### DIFF
--- a/changelog/_unreleased/2020-09-17-add-theme-configuration-field-for-full-width-editing.md
+++ b/changelog/_unreleased/2020-09-17-add-theme-configuration-field-for-full-width-editing.md
@@ -1,0 +1,12 @@
+---
+title:         Add theme configuration field option for full width editing
+issue:         NEXT-9304
+author:        Joshua Behrens
+author_email:  code@joshua-behrens.de
+author_github: JoshuaBehrens
+---
+# Core
+* Added new theme configuration field option `fullWidth` 
+___
+# Administration
+* Changed theme configuration field width depending on the `fullWidth` field option

--- a/src/Administration/Resources/app/administration/test/e2e/cypress/integration/content/sw-theme/use-config.spec.js
+++ b/src/Administration/Resources/app/administration/test/e2e/cypress/integration/content/sw-theme/use-config.spec.js
@@ -1,4 +1,4 @@
-/// <reference types="Cypress" />
+// / <reference types="Cypress" />
 
 import ProductPageObject from '../../../support/pages/module/sw-product.page-object';
 
@@ -23,6 +23,11 @@ describe('Theme: Test loading and saving of theme', () => {
             .click();
 
         cy.get('.sw-theme-manager-detail__area').its('length').should('be.gte', 1);
+
+        // Check whether logo media inputs are full width
+        cy.get('.sw-theme-manager-detail__content--section_field-full-width').contains('Desktop');
+        cy.get('.sw-theme-manager-detail__content--section_field-full-width').contains('Tablet');
+        cy.get('.sw-theme-manager-detail__content--section_field-full-width').contains('Mobile');
     });
 
     it('@base @content: rename theme', () => {

--- a/src/Core/Framework/Changelog/ChangelogReleaseCreator.php
+++ b/src/Core/Framework/Changelog/ChangelogReleaseCreator.php
@@ -152,7 +152,7 @@ class ChangelogReleaseCreator
             $output[] = '---';
             $output[] = 'Update the Upgrade Information in: ' . $this->getTargetUpgradeFile($version, false);
             $output[] = '---';
-            $output[] = implode($append, "\n");
+            $output[] = implode("\n", $append);
         }
     }
 }

--- a/src/Docs/Resources/current/30-theme-guide/20-configuration.md
+++ b/src/Docs/Resources/current/30-theme-guide/20-configuration.md
@@ -154,6 +154,7 @@ The following parameters can be defined for a config field item:
 | section      | Name of a section to organize the config options                                                 |
 | custom       | The defined data will not be processed but is available via API                                  |
 | scss         | If set to false, the config option will not be injected as a SCSS variable                       |
+| fullWidth    | If set to true, the administration component width will be displayed in full width               |
 
 ### Field types
 You can use different field types in your theme manager:

--- a/src/Storefront/Resources/app/administration/src/modules/sw-theme-manager/page/sw-theme-manager-detail/sw-theme-manager-detail.html.twig
+++ b/src/Storefront/Resources/app/administration/src/modules/sw-theme-manager/page/sw-theme-manager-detail/sw-theme-manager-detail.html.twig
@@ -187,7 +187,8 @@
                                                         <sw-container class="sw-theme-manager-detail__content--section_field">
                                                             <div v-for="(field, fieldName) in section.fields"
                                                                  :key="fieldName"
-                                                                 class="sw-theme-manager-detail__content--section_field">
+                                                                 class="sw-theme-manager-detail__content--section_field"
+                                                                 :class="{'sw-theme-manager-detail__content--section_field-full-width': field.fullWidth}">
                                                                 <template v-if="themeConfig[fieldName]">
                                                                     <sw-field
                                                                         v-if="mapSwFieldTypes(field.type) === 'select'"

--- a/src/Storefront/Resources/app/administration/src/modules/sw-theme-manager/page/sw-theme-manager-detail/sw-theme-manager-detail.scss
+++ b/src/Storefront/Resources/app/administration/src/modules/sw-theme-manager/page/sw-theme-manager-detail/sw-theme-manager-detail.scss
@@ -120,6 +120,10 @@
         :not(div.sw-media-upload) .sw-field {
             margin: 0;
         }
+
+        .sw-theme-manager-detail__content--section_field-full-width {
+            grid-column: span 2 / auto;
+        }
     }
 
     .sw-theme-manager-detail__content--section_title {

--- a/src/Storefront/Resources/theme.json
+++ b/src/Storefront/Resources/theme.json
@@ -249,7 +249,8 @@
         "value": "app/storefront/dist/assets/logo/demostore-logo.png",
         "editable": true,
         "block": "media",
-        "order": 100
+        "order": 100,
+        "fullWidth": true
       },
       "sw-logo-tablet": {
         "label": {
@@ -264,7 +265,8 @@
         "value": "app/storefront/dist/assets/logo/demostore-logo.png",
         "editable": true,
         "block": "media",
-        "order": 200
+        "order": 200,
+        "fullWidth": true
       },
       "sw-logo-mobile": {
         "label": {
@@ -279,7 +281,8 @@
         "value": "app/storefront/dist/assets/logo/demostore-logo.png",
         "editable": true,
         "block": "media",
-        "order": 300
+        "order": 300,
+        "fullWidth": true
       },
       "sw-logo-share": {
         "label": {

--- a/src/Storefront/Test/Theme/fixtures/ThemeFixtures.php
+++ b/src/Storefront/Test/Theme/fixtures/ThemeFixtures.php
@@ -558,6 +558,7 @@ class ThemeFixtures
                     'tab' => null,
                     'tabOrder' => null,
                     'scss' => null,
+                    'fullWidth' => null,
                 ],
                 'sw-color-brand-secondary' => [
                     'name' => 'sw-color-brand-secondary',
@@ -579,6 +580,7 @@ class ThemeFixtures
                     'tab' => null,
                     'tabOrder' => null,
                     'scss' => null,
+                    'fullWidth' => null,
                 ],
                 'sw-color-success' => [
                     'name' => 'sw-color-success',
@@ -600,6 +602,7 @@ class ThemeFixtures
                     'tab' => null,
                     'tabOrder' => null,
                     'scss' => null,
+                    'fullWidth' => null,
                 ],
                 'sw-color-info' => [
                     'name' => 'sw-color-info',
@@ -621,6 +624,7 @@ class ThemeFixtures
                     'tab' => null,
                     'tabOrder' => null,
                     'scss' => null,
+                    'fullWidth' => null,
                 ],
                 'sw-color-warning' => [
                     'name' => 'sw-color-warning',
@@ -642,6 +646,7 @@ class ThemeFixtures
                     'tab' => null,
                     'tabOrder' => null,
                     'scss' => null,
+                    'fullWidth' => null,
                 ],
                 'sw-color-danger' => [
                     'name' => 'sw-color-danger',
@@ -663,6 +668,7 @@ class ThemeFixtures
                     'tab' => null,
                     'tabOrder' => null,
                     'scss' => null,
+                    'fullWidth' => null,
                 ],
                 'sw-text-color' => [
                     'name' => 'sw-text-color',
@@ -684,6 +690,7 @@ class ThemeFixtures
                     'tab' => null,
                     'tabOrder' => null,
                     'scss' => null,
+                    'fullWidth' => null,
                 ],
                 'sw-border-color' => [
                     'name' => 'sw-border-color',
@@ -705,6 +712,7 @@ class ThemeFixtures
                     'tab' => null,
                     'tabOrder' => null,
                     'scss' => null,
+                    'fullWidth' => null,
                 ],
                 'sw-background-color' => [
                     'label' => [
@@ -726,6 +734,7 @@ class ThemeFixtures
                     'tab' => null,
                     'tabOrder' => null,
                     'scss' => null,
+                    'fullWidth' => null,
                 ],
                 'sw-color-price' => [
                     'name' => 'sw-color-price',
@@ -747,6 +756,7 @@ class ThemeFixtures
                     'tab' => null,
                     'tabOrder' => null,
                     'scss' => null,
+                    'fullWidth' => null,
                 ],
                 'sw-color-buy-button' => [
                     'name' => 'sw-color-buy-button',
@@ -768,6 +778,7 @@ class ThemeFixtures
                     'tab' => null,
                     'tabOrder' => null,
                     'scss' => null,
+                    'fullWidth' => null,
                 ],
                 'sw-color-buy-button-text' => [
                     'label' => [
@@ -789,6 +800,7 @@ class ThemeFixtures
                     'tab' => null,
                     'tabOrder' => null,
                     'scss' => null,
+                    'fullWidth' => null,
                 ],
                 'sw-font-family-base' => [
                     'name' => 'sw-font-family-base',
@@ -810,6 +822,7 @@ class ThemeFixtures
                     'tab' => null,
                     'tabOrder' => null,
                     'scss' => null,
+                    'fullWidth' => null,
                 ],
                 'sw-font-family-headline' => [
                     'name' => 'sw-font-family-headline',
@@ -831,6 +844,7 @@ class ThemeFixtures
                     'tab' => null,
                     'tabOrder' => null,
                     'scss' => null,
+                    'fullWidth' => null,
                 ],
                 'sw-headline-color' => [
                     'label' => [
@@ -852,6 +866,7 @@ class ThemeFixtures
                     'tab' => null,
                     'tabOrder' => null,
                     'scss' => null,
+                    'fullWidth' => null,
                 ],
                 'sw-logo-desktop' => [
                     'label' => [
@@ -876,6 +891,7 @@ class ThemeFixtures
                     'tab' => null,
                     'tabOrder' => null,
                     'scss' => null,
+                    'fullWidth' => true,
                 ],
                 'sw-logo-tablet' => [
                     'label' => [
@@ -900,6 +916,7 @@ class ThemeFixtures
                     'tab' => null,
                     'tabOrder' => null,
                     'scss' => null,
+                    'fullWidth' => true,
                 ],
                 'sw-logo-mobile' => [
                     'label' => [
@@ -924,6 +941,7 @@ class ThemeFixtures
                     'tab' => null,
                     'tabOrder' => null,
                     'scss' => null,
+                    'fullWidth' => true,
                 ],
                 'sw-logo-share' => [
                     'label' => [
@@ -945,6 +963,7 @@ class ThemeFixtures
                     'tab' => null,
                     'tabOrder' => null,
                     'scss' => null,
+                    'fullWidth' => null,
                 ],
                 'sw-logo-favicon' => [
                     'label' => [
@@ -966,6 +985,7 @@ class ThemeFixtures
                     'tab' => null,
                     'tabOrder' => null,
                     'scss' => null,
+                    'fullWidth' => null,
                 ],
             ],
         ];
@@ -1033,6 +1053,7 @@ class ThemeFixtures
                     'tab' => null,
                     'tabOrder' => null,
                     'scss' => null,
+                    'fullWidth' => null,
                 ],
                 'sw-color-brand-secondary' => [
                     'name' => 'sw-color-brand-secondary',
@@ -1054,6 +1075,7 @@ class ThemeFixtures
                     'tab' => null,
                     'tabOrder' => null,
                     'scss' => null,
+                    'fullWidth' => null,
                 ],
                 'sw-color-success' => [
                     'name' => 'sw-color-success',
@@ -1075,6 +1097,7 @@ class ThemeFixtures
                     'tab' => null,
                     'tabOrder' => null,
                     'scss' => null,
+                    'fullWidth' => null,
                 ],
                 'sw-color-info' => [
                     'name' => 'sw-color-info',
@@ -1096,6 +1119,7 @@ class ThemeFixtures
                     'tab' => null,
                     'tabOrder' => null,
                     'scss' => null,
+                    'fullWidth' => null,
                 ],
                 'sw-color-warning' => [
                     'name' => 'sw-color-warning',
@@ -1117,6 +1141,7 @@ class ThemeFixtures
                     'tab' => null,
                     'tabOrder' => null,
                     'scss' => null,
+                    'fullWidth' => null,
                 ],
                 'sw-color-danger' => [
                     'name' => 'sw-color-danger',
@@ -1138,6 +1163,7 @@ class ThemeFixtures
                     'tab' => null,
                     'tabOrder' => null,
                     'scss' => null,
+                    'fullWidth' => null,
                 ],
                 'sw-text-color' => [
                     'name' => 'sw-text-color',
@@ -1159,6 +1185,7 @@ class ThemeFixtures
                     'tab' => null,
                     'tabOrder' => null,
                     'scss' => null,
+                    'fullWidth' => null,
                 ],
                 'sw-border-color' => [
                     'name' => 'sw-border-color',
@@ -1180,6 +1207,7 @@ class ThemeFixtures
                     'tab' => null,
                     'tabOrder' => null,
                     'scss' => null,
+                    'fullWidth' => null,
                 ],
                 'sw-background-color' => [
                     'label' => [
@@ -1201,6 +1229,7 @@ class ThemeFixtures
                     'tab' => null,
                     'tabOrder' => null,
                     'scss' => null,
+                    'fullWidth' => null,
                 ],
                 'sw-color-price' => [
                     'name' => 'sw-color-price',
@@ -1222,6 +1251,7 @@ class ThemeFixtures
                     'tab' => null,
                     'tabOrder' => null,
                     'scss' => null,
+                    'fullWidth' => null,
                 ],
                 'sw-color-buy-button' => [
                     'name' => 'sw-color-buy-button',
@@ -1243,6 +1273,7 @@ class ThemeFixtures
                     'tab' => null,
                     'tabOrder' => null,
                     'scss' => null,
+                    'fullWidth' => null,
                 ],
                 'sw-color-buy-button-text' => [
                     'label' => [
@@ -1264,6 +1295,7 @@ class ThemeFixtures
                     'tab' => null,
                     'tabOrder' => null,
                     'scss' => null,
+                    'fullWidth' => null,
                 ],
                 'sw-font-family-base' => [
                     'name' => 'sw-font-family-base',
@@ -1285,6 +1317,7 @@ class ThemeFixtures
                     'tab' => null,
                     'tabOrder' => null,
                     'scss' => null,
+                    'fullWidth' => null,
                 ],
                 'sw-font-family-headline' => [
                     'name' => 'sw-font-family-headline',
@@ -1306,6 +1339,7 @@ class ThemeFixtures
                     'tab' => null,
                     'tabOrder' => null,
                     'scss' => null,
+                    'fullWidth' => null,
                 ],
                 'sw-headline-color' => [
                     'label' => [
@@ -1327,6 +1361,7 @@ class ThemeFixtures
                     'tab' => null,
                     'tabOrder' => null,
                     'scss' => null,
+                    'fullWidth' => null,
                 ],
                 'sw-logo-desktop' => [
                     'label' => [
@@ -1351,6 +1386,7 @@ class ThemeFixtures
                     'tab' => null,
                     'tabOrder' => null,
                     'scss' => null,
+                    'fullWidth' => null,
                 ],
                 'sw-logo-tablet' => [
                     'label' => [
@@ -1375,6 +1411,7 @@ class ThemeFixtures
                     'tab' => null,
                     'tabOrder' => null,
                     'scss' => null,
+                    'fullWidth' => null,
                 ],
                 'sw-logo-mobile' => [
                     'label' => [
@@ -1399,6 +1436,7 @@ class ThemeFixtures
                     'tab' => null,
                     'tabOrder' => null,
                     'scss' => null,
+                    'fullWidth' => null,
                 ],
                 'sw-logo-share' => [
                     'label' => [
@@ -1420,6 +1458,7 @@ class ThemeFixtures
                     'tab' => null,
                     'tabOrder' => null,
                     'scss' => null,
+                    'fullWidth' => null,
                 ],
                 'sw-logo-favicon' => [
                     'label' => [
@@ -1441,6 +1480,7 @@ class ThemeFixtures
                     'tab' => null,
                     'tabOrder' => null,
                     'scss' => null,
+                    'fullWidth' => null,
                 ],
             ],
         ];

--- a/src/Storefront/Theme/ThemeConfigField.php
+++ b/src/Storefront/Theme/ThemeConfigField.php
@@ -78,6 +78,11 @@ class ThemeConfigField extends Struct
      */
     protected $scss;
 
+    /**
+     * @var bool|null
+     */
+    protected $fullWidth;
+
     public function getName(): string
     {
         return $this->name;
@@ -226,5 +231,15 @@ class ThemeConfigField extends Struct
     public function setScss(?bool $scss): void
     {
         $this->scss = $scss;
+    }
+
+    public function getFullWidth(): ?bool
+    {
+        return $this->fullWidth;
+    }
+
+    public function setFullWidth(?bool $fullWidth): void
+    {
+        $this->fullWidth = $fullWidth;
     }
 }

--- a/src/Storefront/Theme/ThemeService.php
+++ b/src/Storefront/Theme/ThemeService.php
@@ -266,6 +266,7 @@ class ThemeService
                 'helpText' => $fieldConfig['helpText'] ?? null,
                 'type' => $fieldConfig['type'],
                 'custom' => $fieldConfig['custom'],
+                'fullWidth' => $fieldConfig['fullWidth'],
             ];
         }
 


### PR DESCRIPTION
### 1. Why is this change necessary?
When you use text, media or wysiwyg components in your theme configuration the fields are very small as the administration splits the configuration section into two columns.

### 2. What does this change do, exactly?
Fix an unrelated bug that `implode` is used wrong.
Add new new field for theme configuration fields.
Add a new class in the administration that makes a full width column in the grid.
Make logo fields full width.

### 3. Describe each step to reproduce the issue or behaviour.
1. Use a wysiwyg field
2. Open in admin
3. See only a few 100 pixel for editing which can't contain the full wysiwyg utilities

### 4. Please link to the relevant issues (if any).
NEXT-9304

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/master/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
