### PR TITLE
NEXT-8426 - Save user settings in listing views

### DIFF
--- a/changelog/_unreleased/2020-09-17-save-user-settings-in-listing-views.md
+++ b/changelog/_unreleased/2020-09-17-save-user-settings-in-listing-views.md
@@ -1,0 +1,9 @@
+---
+title: Save user settings in listing views
+issue: NEXT-8426
+author: Clemens Brockschmidt
+author_email: clemens.brockschmidt@gmail.com 
+author_github: @cbrockschmidt
+---
+# Administration
+* Changed `src/Administration/Resources/app/administration/src/app/component/data-grid/sw-data-grid/index.js` to save settings made to enabling compact mode and previews in listing views.

--- a/src/Administration/Resources/app/administration/src/app/component/data-grid/sw-data-grid/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/data-grid/sw-data-grid/index.js
@@ -199,7 +199,7 @@ Component.register('sw-data-grid', {
         },
 
         localStorageItemKey() {
-            return `${this.identifier}-grid-columns`;
+            return `${this.identifier}-grid`;
         },
 
         selectionCount() {
@@ -271,6 +271,7 @@ Component.register('sw-data-grid', {
     methods: {
         createdComponent() {
             this.initGridColumns();
+            this.initCompactModeAndShowPreviews();
         },
 
         mountedComponent() {
@@ -290,13 +291,26 @@ Component.register('sw-data-grid', {
                 const storageItem = window.localStorage.getItem(this.localStorageItemKey);
 
                 if (storageItem !== null) {
-                    columns = JSON.parse(storageItem);
+                    columns = JSON.parse(storageItem).columns;
                 }
             }
 
             this.currentColumns = columns;
 
             this.findResizeColumns();
+        },
+
+        initCompactModeAndShowPreviews() {
+            if (!this.identifier) {
+                return;
+            }
+
+            const storageItem = window.localStorage.getItem(this.localStorageItemKey);
+
+            if (storageItem !== null) {
+                this.compact = JSON.parse(storageItem).compact;
+                this.previews = JSON.parse(storageItem).previews;
+            }
         },
 
         findResizeColumns() {
@@ -334,11 +348,21 @@ Component.register('sw-data-grid', {
             });
         },
 
+        // @deprecated tag:v6.4.0
         saveGridColumns() {
             if (!this.identifier) {
                 return;
             }
             window.localStorage.setItem(this.localStorageItemKey, JSON.stringify(this.currentColumns));
+        },
+
+        saveUserSettings() {
+            if (!this.identifier) {
+                return;
+            }
+
+            const userSettings = { columns: this.currentColumns, compact: this.compact, previews: this.previews };
+            window.localStorage.setItem(this.localStorageItemKey, JSON.stringify(userSettings));
         },
 
         getHeaderCellClasses(column, index) {
@@ -374,19 +398,27 @@ Component.register('sw-data-grid', {
 
         onChangeCompactMode(value) {
             this.compact = value;
+            this.saveUserSettings();
         },
 
         onChangePreviews(value) {
             this.previews = value;
+            this.saveUserSettings();
         },
 
         onChangeColumnVisibility(value, index) {
             this.currentColumns[index].visible = value;
+            this.saveUserSettings();
+
+            // @deprecated tag:v6.4.0 - use saveUserSettings instead
             this.saveGridColumns();
         },
 
         onChangeColumnOrder(currentColumnIndex, newColumnIndex) {
             this.currentColumns = this.orderColumns(this.currentColumns, currentColumnIndex, newColumnIndex);
+            this.saveUserSettings();
+
+            // @deprecated tag:v6.4.0 - use saveUserSettings instead
             this.saveGridColumns();
         },
 
@@ -418,6 +450,9 @@ Component.register('sw-data-grid', {
 
         hideColumn(columnIndex) {
             this.currentColumns[columnIndex].visible = false;
+            this.saveUserSettings();
+
+            // @deprecated tag:v6.4.0 - use saveUserSettings instead
             this.saveGridColumns();
         },
 


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/contribution/contribution-guideline?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?

User settings like compact mode and previews were not saved upon reloading a window containing a listing view.

### 2. What does this change do, exactly?

Save the user settings in the local storage.

![Video](https://user-images.githubusercontent.com/6626633/93472358-cf309e00-f8f4-11ea-8aed-7a484ab787c5.gif)


### 3. Describe each step to reproduce the issue or behaviour.

Navigate to a listing view (e.g. Products), go to list settings and change compact mode or preview settings.

### 4. Please link to the relevant issues (if any).

* https://github.com/shopwareBoostDay/platform/issues/58 
* NEXT-8426

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/master/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
