### PR TITLE
NEXT-10853 - Add entity cache service

### DIFF
--- a/changelog/_unreleased/2020-09-17-add-entity-cache-service.md
+++ b/changelog/_unreleased/2020-09-17-add-entity-cache-service.md
@@ -1,0 +1,9 @@
+---
+title:              Add entity cache service
+issue:              NEXT-10853
+author:             Hannes Wernery
+author_email:       hannes.wernery@pickware.de
+author_github:      @hanneswernery
+---
+# Administration
+* Adds an entity cache service (`entityCache`) to fetch entities that will probably not change during runtime more efficiently. It also provides entity-specific convenience functions (i.e. for entity `state_machine`).

--- a/src/Administration/Resources/app/administration/src/app/init/repository.init.js
+++ b/src/Administration/Resources/app/administration/src/app/init/repository.init.js
@@ -1,5 +1,5 @@
 const RepositoryFactory = Shopware.Classes._private.RepositoryFactory;
-const { EntityHydrator, ChangesetGenerator, EntityFactory } = Shopware.Data;
+const { EntityHydrator, ChangesetGenerator, EntityCache, EntityFactory } = Shopware.Data;
 const ErrorResolverError = Shopware.DataDeprecated.ErrorResolver;
 
 export default function initializeRepositoryFactory(container) {
@@ -21,18 +21,23 @@ export default function initializeRepositoryFactory(container) {
         const changesetGenerator = new ChangesetGenerator();
         const entityFactory = new EntityFactory();
         const errorResolver = new ErrorResolverError();
+        const createRepositoryFactory = () => new RepositoryFactory(
+            hydrator,
+            changesetGenerator,
+            entityFactory,
+            httpClient,
+            errorResolver
+        );
+        const entityCache = new EntityCache(createRepositoryFactory());
 
         this.addServiceProvider('repositoryFactory', () => {
-            return new RepositoryFactory(
-                hydrator,
-                changesetGenerator,
-                entityFactory,
-                httpClient,
-                errorResolver
-            );
+            return createRepositoryFactory();
         });
         this.addServiceProvider('entityHydrator', () => {
             return hydrator;
+        });
+        this.addServiceProvider('entityCache', () => {
+            return entityCache;
         });
         this.addServiceProvider('entityFactory', () => {
             return entityFactory;

--- a/src/Administration/Resources/app/administration/src/core/data-new/entity-cache-helper/state-machine-helper.js
+++ b/src/Administration/Resources/app/administration/src/core/data-new/entity-cache-helper/state-machine-helper.js
@@ -1,0 +1,50 @@
+import Criteria from '../criteria.data';
+
+const REPOSITORY_NAME = 'state_machine';
+const TECHNICAL_NAME_ORDER_STATE = 'order.state';
+const TECHNICAL_NAME_ORDER_DELIVERY_STATE = 'order_delivery.state';
+const TECHNICAL_NAME_ORDER_TRANSACTION_STATE = 'order_transaction.state';
+
+class StateMachineCacheHelper {
+    constructor(repositoryFactory) {
+        this.repositoryFactory = repositoryFactory;
+        this.clearCache();
+    }
+
+    clearCache() {
+        this.stateMachines = null;
+    }
+
+    async getOrderStates(context) {
+        return (await this.getStateMachineByTechnicalName(TECHNICAL_NAME_ORDER_STATE, context)).states;
+    }
+
+    async getOrderDeliveryStates(context) {
+        return (await this.getStateMachineByTechnicalName(TECHNICAL_NAME_ORDER_DELIVERY_STATE, context)).states;
+    }
+
+    async getOrderTransactionStates(context) {
+        return (await this.getStateMachineByTechnicalName(TECHNICAL_NAME_ORDER_TRANSACTION_STATE, context)).states;
+    }
+
+    async getStateMachineByTechnicalName(technicalName, context) {
+        if (!this.stateMachines) {
+            await this.fetchStates(context);
+        }
+
+        return this.stateMachines.find((stateMachine) => stateMachine.technicalName === technicalName) || {};
+    }
+
+    async fetchStates(context) {
+        this.stateMachines = await this.repositoryFactory.create(REPOSITORY_NAME).search(this.getCriteria(), context);
+    }
+
+    getCriteria() {
+        const criteria = new Criteria(1, 500);
+        criteria.addAssociation('states');
+
+        return criteria;
+    }
+}
+
+export default StateMachineCacheHelper;

--- a/src/Administration/Resources/app/administration/src/core/data-new/entity-cache.data.js
+++ b/src/Administration/Resources/app/administration/src/core/data-new/entity-cache.data.js
@@ -1,0 +1,40 @@
+import Criteria from './criteria.data';
+import StateMachineCacheHelper from './entity-cache-helper/state-machine-helper';
+
+class EntityCache {
+    constructor(repositoryFactory) {
+        this.repositoryFactory = repositoryFactory;
+        this.clearCaches();
+    }
+
+    clearCaches() {
+        this.cachedEntities = {};
+        this.stateMachineCacheHelper = new StateMachineCacheHelper(this.repositoryFactory);
+    }
+
+    clearCache(entityName) {
+        delete this.cachedEntities[entityName];
+    }
+
+    async find(id, entityName, context) {
+        const entities = await this.findAll(entityName, context);
+
+        return entities.find((entity) => entity.id === id);
+    }
+
+    async findAll(entityName, context) {
+        if (!this.cachedEntities[entityName]) {
+            this.cachedEntities[entityName] = await this.fetchFromRepository(entityName, context);
+        }
+
+        return this.cachedEntities[entityName];
+    }
+
+    fetchFromRepository(entityName, context) {
+        return this.repositoryFactory
+            .create(entityName)
+            .search(new Criteria(1, 500), context);
+    }
+}
+
+export default EntityCache;

--- a/src/Administration/Resources/app/administration/src/core/data-new/index.js
+++ b/src/Administration/Resources/app/administration/src/core/data-new/index.js
@@ -1,6 +1,7 @@
 import ChangesetGenerator from './changeset-generator.data';
 import Criteria from './criteria.data';
 import Entity from './entity.data';
+import EntityCache from './entity-cache.data';
 import EntityCollection from './entity-collection.data';
 import EntityDefinition from './entity-definition.data';
 import EntityFactory from './entity-factory.data';
@@ -11,6 +12,7 @@ export default {
     ChangesetGenerator,
     Criteria,
     Entity,
+    EntityCache,
     EntityCollection,
     EntityDefinition,
     EntityFactory,


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/contribution/contribution-guideline?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?

When working in the administration we often have to fetch the same entities across multiple components or pages. Some entities like `state_machine_state`, `state_machine_transition`, maybe `currency`, `language`, `locale` are less likely to change over time or at least they change rarely but they are still fetched multiple times and return the same results.


### 2. What does this change do, exactly?

This PR adds a central `entityCache` service that can be used in any component to fetch entities "with caching". That means once an entity is fetched via this service, the result is stored within the service instance. Any upcoming fetch will use this cached result to return the entity instantaneously (without sending another request).
This service an also provide entity-specific convenience functions. This PR adds such functions for the `state_machine` entity.

I did not add usages to the existing Shopware code (yet). The LocaleToLanguage service would be a good candidate to use this entity cache: https://github.com/shopwareBoostDay/platform/blob/e7337df2c3edd055b7bc0a8bc29b1b3a9666cb10/src/Administration/Resources/app/administration/src/app/service/locale-to-language.service.js

I am looking forward to your feedback 🙌 

**Pros:**

- Reoccurring requests can be stripped by using the cached result
- The usage of this service is completely optional
- The cache can be cleared globally or for a specific entity (e.g. when a entity is changed in the administration, it can also clear the cache manually)
- Convenience functions for specific entities can make the entity handling easier and avoids code duplication

**Limitations:**

- The service does not support filters other than by id.
- The cache is limited to 500 objects per entity name (due to API limitation)
- No associations are cached

Injection in a component:
```js
   inject: [ 'entityCache' ],
```

Usage across components:
```js
  // Basic usage. The service uses a single request
  const languages = await this.entityCache.findAll('language', Context.api);
  const language = await this.entityCache.find(someId, Context.api);
  const languagesAgain = await this.entityCache.findAll('language', Context.api);

  // Clear cache and fetch anew.
  this.entityCache.clearCache('language');
  const languages = await this.entityCache.findAll('language', Context.api);

  // Clear all caches and fetch anew.
  this.entityCache.clearCaches();
  const languages = await this.entityCache.findAll('language', Context.api);
  const locales = await this.entityCache.findAll('locale', Context.api);

  // State machine helper usage. The service uses a single request
  const stateMachineHelper = this.entityCache.stateMachineCacheHelper;
  const orderStates = await stateMachineHelper.getOrderStates(Context.api);
  const orderDeliveryStates = await stateMachineHelper.getOrderDeliveryStates(Context.api);
  const orderTransactionStates = await stateMachineHelper.getOrderTransactionStates(Context.api);
```



### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).

Issue: https://github.com/shopwareBoostDay/platform/issues/112

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/master/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
