### PR TITLE
NEXT-8309 - Add address to customer selection

### DIFF
--- a/changelog/_unreleased/2020-09-17-add-address-to-customer-selection-in-add-order.md
+++ b/changelog/_unreleased/2020-09-17-add-address-to-customer-selection-in-add-order.md
@@ -1,0 +1,11 @@
+---
+title: Add address to customer selection in add order
+issue: NEXT-8309
+author: Alexander Batenburg
+author_email: alexander@h1.nl 
+author_github: @alexbaat
+---
+# Administration
+*  Added customer default billing address info below customer name in customer selectbox in `src/module/sw-order/component/sw-order-create-details-header/sw-order-create-details-header.html.twig`
+*  Added css for properly displaying address in `src/module/sw-order/page/sw-order-create/sw-order-create.scss`
+*  Added `customerCriteria` in `src/module/sw-order/component/sw-order-create-details-header/index.js` for associate customer with billingAddress

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-create-details-header/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-create-details-header/index.js
@@ -1,6 +1,7 @@
 import template from './sw-order-create-details-header.html.twig';
 
 const { Component } = Shopware;
+const { Criteria } = Shopware.Data;
 
 Component.register('sw-order-create-details-header', {
     template,
@@ -39,6 +40,13 @@ Component.register('sw-order-create-details-header', {
             set(customerId) {
                 if (this.customer) this.customer.id = customerId;
             }
+        },
+        customerCriteria() {
+            const criteria = new Criteria(1, 25);
+
+            criteria.addAssociation('defaultBillingAddress.country');
+
+            return criteria;
         }
     },
 

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-create-details-header/sw-order-create-details-header.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-create-details-header/sw-order-create-details-header.html.twig
@@ -38,6 +38,7 @@
                                 <sw-entity-single-select
                                     size="small"
                                     entity="customer"
+                                    :criteria="customerCriteria"
                                     labelProperty="firstName"
                                     :value="customerId"
                                     :placeholder="$tc('sw-order.createBase.detailsHeader.placeholder')"
@@ -58,41 +59,53 @@
                                                 v-bind="{ item, index }"
                                                 class="sw-order-create-details-header__customer-result">
                                                 {% block sw_order_create_search_customer_slot_result_item_content_container %}
-                                                    <div class="sw-order-create-details-header__customer-result-item">
-                                                        {% block sw_order_create_search_customer_slot_result_item_number %}
-                                                            <sw-highlight-text
-                                                                v-if="highlightSearchTerm"
-                                                                :text="getKey(item, 'customerNumber') || getKey(item, `translated.customerNumber`)"
-                                                                :searchTerm="searchTerm">
-                                                            </sw-highlight-text>
-                                                        {% endblock %}
-                                                    </div>
 
                                                     <div class="sw-order-create-details-header__customer-result-item has-many-childrens">
-                                                        {% block sw_order_create_search_customer_slot_result_item_firstname %}
-                                                            <sw-highlight-text
+                                                        <div>
+                                                            {% block sw_order_create_search_customer_slot_result_item_firstname %}
+                                                                <sw-highlight-text
+                                                                    v-if="highlightSearchTerm"
+                                                                    :text="getKey(item, 'firstName') || getKey(item, `translated.firstName`)"
+                                                                    :searchTerm="searchTerm">
+                                                                </sw-highlight-text>
+                                                            {% endblock %}
+
+                                                            {% block sw_order_create_search_customer_slot_result_item_lastname %}
+                                                                <sw-highlight-text
+                                                                    v-if="highlightSearchTerm"
+                                                                    :text="getKey(item, 'lastName') || getKey(item, `translated.lastName`)"
+                                                                    :searchTerm="searchTerm">
+                                                                </sw-highlight-text>
+                                                            {% endblock %}
+                                                        </div>
+
+                                                        {% block sw_order_create_search_customer_slot_result_item_number %}
+                                                        <sw-highlight-text
                                                                 v-if="highlightSearchTerm"
-                                                                :text="getKey(item, 'firstName') || getKey(item, `translated.firstName`)"
-                                                                :searchTerm="searchTerm">
-                                                            </sw-highlight-text>
+                                                                :text="getKey(item, 'customerNumber') || getKey(item, `translated.customerNumber`)"
+                                                                :searchTerm="searchTerm"
+                                                                class="text-truncate">
+                                                        </sw-highlight-text>
                                                         {% endblock %}
 
-                                                        {% block sw_order_create_search_customer_slot_result_item_lastname %}
-                                                            <sw-highlight-text
-                                                                v-if="highlightSearchTerm"
-                                                                :text="getKey(item, 'lastName') || getKey(item, `translated.lastName`)"
-                                                                :searchTerm="searchTerm">
-                                                            </sw-highlight-text>
-                                                        {% endblock %}
                                                     </div>
 
-                                                    <div class="sw-order-create-details-header__customer-result-item">
+
+                                                    <div v-if="getKey(item, 'company') || getKey(item, `translated.company`)" class="sw-order-create-details-header__customer-result-item">
                                                         {% block sw_order_create_search_customer_slot_result_item_company %}
                                                             <sw-highlight-text
                                                                 v-if="highlightSearchTerm"
                                                                 :text="getKey(item, 'company') || getKey(item, `translated.company`)"
                                                                 :searchTerm="searchTerm">
                                                             </sw-highlight-text>
+                                                        {% endblock %}
+                                                    </div>
+
+                                                    <div class="sw-order-create-details-header__customer-result-item text-gray-500">
+                                                        {% block sw_order_create_search_customer_slot_result_item_address %}
+                                                        {{ item.defaultBillingAddress.street }} <br />
+                                                        {{ item.defaultBillingAddress.zipcode }} {{ item.defaultBillingAddress.city }} <br />
+                                                        {{ item.defaultBillingAddress.country.name }}
                                                         {% endblock %}
                                                     </div>
                                                 {% endblock %}

--- a/src/Administration/Resources/app/administration/src/module/sw-order/page/sw-order-create/sw-order-create.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/page/sw-order-create/sw-order-create.scss
@@ -6,7 +6,7 @@ $sw-order-user-card: '.sw-order-user-card';
 $sw-highlight-text: '.sw-highlight-text';
 $font-weight-semi-bold: 600;
 
-$select-result-customer-item-first-width: 40px;
+$select-result-customer-item-last-width: 40px;
 $select-result-customer-item-gutter: 10px;
 
 .sw-order-create {
@@ -23,13 +23,11 @@ $select-result-customer-item-gutter: 10px;
 
 .sw-order-create-details-header {
     &__customer-result-item {
-        min-width: calc(50% - (#{$select-result-customer-item-first-width} + #{$select-result-customer-item-gutter}));
-        max-width: calc(50% - (#{$select-result-customer-item-first-width} + #{$select-result-customer-item-gutter}));
-        margin: 0 $select-result-customer-item-gutter;
 
         &.has-many-childrens {
             display: flex;
             white-space: nowrap;
+            justify-content: space-between;
 
             #{$sw-highlight-text} {
                 @include reset-truncate;
@@ -37,18 +35,15 @@ $select-result-customer-item-gutter: 10px;
                 display: inline-block;
                 width: auto;
 
-                &:last-child {
-                    @include truncate;
-
-                    margin-left: 5px;
-                }
             }
         }
 
-        &:first-child {
-            min-width: $select-result-customer-item-first-width;
-            max-width: $select-result-customer-item-first-width;
+        .text-truncate {
+            @include truncate;
+            min-width: $select-result-customer-item-last-width;
+            max-width: $select-result-customer-item-last-width;
             color: $color-gray-500;
+            margin-left: 5px;
         }
 
         #{$sw-highlight-text} {
@@ -173,7 +168,7 @@ $select-result-customer-item-gutter: 10px;
     &.sw-order-create-details-header__customer-result {
         @include transition;
 
-        border-bottom: 0;
+        border-bottom: 1px solid $color-gray-500;
 
         #{$this}__result-item-text {
             width: 100%;
@@ -181,6 +176,10 @@ $select-result-customer-item-gutter: 10px;
 
         .sw-icon {
             @include hidden;
+        }
+
+        .text-gray-500 {
+            color: $color-gray-500;
         }
     }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/contribution/contribution-guideline?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
When you search for a customer it can happen that a customer has multiple accounts but with different addresses. By adding the address below the customer name it makes it more clear.

### 2. What does this change do, exactly?
It displays the customer defaultBillingAddress below the customer and company name.

### 3. Describe each step to reproduce the issue or behaviour.
Go to Orders - Overview  and click 'Add order'. In the new page you can search for a customer. In the result list the customer info is displayed with the billingAddress info.

### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/NEXT-8309

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/master/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
