### PR TITLE
NEXT-9188 - Add empty state to sw-property-search result list

### DIFF
--- a/changelog/_unreleased/2020-09-17-add-empty-state-to-sw-property-search-result-list.md
+++ b/changelog/_unreleased/2020-09-17-add-empty-state-to-sw-property-search-result-list.md
@@ -1,0 +1,9 @@
+---
+title: Add empty state to the sw-property-search result list
+issue: NEXT-9188
+author: Eric Mandersloot
+author_email: eric@h1.nl 
+author_github: @eric2o13
+---
+# Administration
+* Added `sw-empty-state` to `sw-property-search` result list

--- a/src/Administration/Resources/app/administration/src/app/component/base/sw-property-search/sw-property-search.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/base/sw-property-search/sw-property-search.html.twig
@@ -124,9 +124,9 @@
 
         {% block sw_property_search_option_search %}
             <div class="sw-property-search__search-selection" v-if="displaySearch">
-
                 {% block sw_property_search_option_search_grid %}
                     <sw-grid class="sw-property-search__search-selection__option_grid"
+                             v-if="groupOptions.length > 0"
                              ref="optionSearchGrid"
                              :items="groupOptions"
                              :header="false"
@@ -158,6 +158,11 @@
                         </template>
                     </sw-grid>
                 {% endblock %}
+                <sw-empty-state v-else
+                                :title="$tc('sw-property-search.noPropertiesFound')"
+                                :subline="$tc('sw-property-search.noPropertiesFoundDescription')">
+                </sw-empty-state>
+
             </div>
         {% endblock %}
 

--- a/src/Administration/Resources/app/administration/src/app/snippet/de-DE.json
+++ b/src/Administration/Resources/app/administration/src/app/snippet/de-DE.json
@@ -754,7 +754,9 @@
   },
   "sw-property-search": {
     "placeholderSearch": "Suche nach Eigenschaften ...",
-    "selected": "{count} Option ausgewählt | {count} Optionen ausgewählt"
+    "selected": "{count} Option ausgewählt | {count} Optionen ausgewählt",
+    "noPropertiesFound": "Keine Optionen gefunden",
+    "noPropertiesFoundDescription": "Versuche es mit einem anderen Suchbegriff."
   },
   "sw-property-assignment": {
     "columnGroup": "Eigenschaft",

--- a/src/Administration/Resources/app/administration/src/app/snippet/en-GB.json
+++ b/src/Administration/Resources/app/administration/src/app/snippet/en-GB.json
@@ -754,7 +754,9 @@
     },
     "sw-property-search": {
         "placeholderSearch": "Search properties...",
-        "selected": "{count} option selected | {count} options selected"
+        "selected": "{count} option selected | {count} options selected",
+        "noPropertiesFound": "No properties found",
+        "noPropertiesFoundDescription": "Try another search phrase."
     },
     "sw-property-assignment": {
         "columnGroup": "Property",


### PR DESCRIPTION
### 1. What does this change do, exactly?
Shows an empty state in the sw-property-search when no results are found.

### 2. Describe each step to reproduce the issue or behaviour.
- Visit the product edit page in the Administration.
- Click on tab 'property assignment' 
- Search for the 'Available properties' 
- Type a non-existing searchphrase.

### 3. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/master/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.

This is how it looked:

![](https://user-images.githubusercontent.com/44392193/90765998-29851180-e2eb-11ea-868f-194447656ce9.png)


This is how it looks now:

![Screenshot 2020-09-17 at 14 40 30](https://user-images.githubusercontent.com/4716311/93473107-e328cf80-f8f5-11ea-9ef7-9ce7f7ead7b7.png)
