### PR TITLE
NEXT-10855 - Add ability to search by Custom Fields in Admin Backend

### DIFF
--- a/changelog/_unreleased/2020-09-17-add-ability-to-search-by-custom-field-in-administration-backend.md
+++ b/changelog/_unreleased/2020-09-17-add-ability-to-search-by-custom-field-in-administration-backend.md
@@ -1,7 +1,7 @@
 ---
 title: Add ability to search by Custom Fields in Administration Backend
 issue: NEXT-10855
-author: Mroczny Czesiek, Wojciech Milek
+author: Mroczny Czesiek
 author_email: mrocznyczesiek@gmail.com
 author_github: @MroczyCzesiek
 ---

--- a/changelog/_unreleased/2020-09-17-add-ability-to-search-by-custom-field-in-administration-backend.md
+++ b/changelog/_unreleased/2020-09-17-add-ability-to-search-by-custom-field-in-administration-backend.md
@@ -2,10 +2,8 @@
 title: Add ability to search by Custom Fields in Administration Backend
 issue: NEXT-10855
 author: Mroczny Czesiek, Wojciech Milek
-author_email: mrocznyczesiek@gmail.com, wojciechus@hotmail.com 
-author_github: @MroczyCzesiek, @wojciechus
+author_email: mrocznyczesiek@gmail.com
+author_github: @MroczyCzesiek
 ---
 # Core
 * Added `SearchRanking` flag to `customFields` in `ProductDefinition`, `CustomerDefinition` and `ProductManufacturerDefinition`
-* It has no impact on the Storefront search functionality
-* Tested on the shop with 6000+ products - no significant impact on search performance

--- a/changelog/_unreleased/2020-09-17-add-ability-to-search-by-custom-field-in-administration-backend.md
+++ b/changelog/_unreleased/2020-09-17-add-ability-to-search-by-custom-field-in-administration-backend.md
@@ -1,0 +1,11 @@
+---
+title: Add ability to search by Custom Fields in Administration Backend
+issue: NEXT-10855
+author: Mroczny Czesiek, Wojciech Milek
+author_email: mrocznyczesiek@gmail.com, wojciechus@hotmail.com 
+author_github: @MroczyCzesiek, @wojciechus
+---
+# Core
+* Added `SearchRanking` flag to `customFields` in `ProductDefinition`, `CustomerDefinition` and `ProductManufacturerDefinition`
+* It has no impact on the Storefront search functionality
+* Tested on the shop with 6000+ products - no significant impact on search performance

--- a/src/Core/Checkout/Customer/CustomerDefinition.php
+++ b/src/Core/Checkout/Customer/CustomerDefinition.php
@@ -111,7 +111,7 @@ class CustomerDefinition extends EntityDefinition
             new DateField('birthday', 'birthday'),
             (new DateTimeField('last_order_date', 'lastOrderDate'))->addFlags(new WriteProtected(Context::SYSTEM_SCOPE)),
             (new IntField('order_count', 'orderCount'))->addFlags(new WriteProtected(Context::SYSTEM_SCOPE)),
-            (new CustomFields())->addFlags(new SearchRanking(SearchRanking::HIGH_SEARCH_RANKING)),
+            (new CustomFields())->addFlags(new SearchRanking(SearchRanking::MIDDLE_SEARCH_RANKING)),
             (new StringField('legacy_password', 'legacyPassword'))->addFlags(new ReadProtected(SalesChannelApiSource::class, AdminApiSource::class)),
             (new StringField('legacy_encoder', 'legacyEncoder'))->addFlags(new ReadProtected(SalesChannelApiSource::class, AdminApiSource::class)),
             new ManyToOneAssociationField('group', 'customer_group_id', CustomerGroupDefinition::class, 'id', false),

--- a/src/Core/Checkout/Customer/CustomerDefinition.php
+++ b/src/Core/Checkout/Customer/CustomerDefinition.php
@@ -111,7 +111,7 @@ class CustomerDefinition extends EntityDefinition
             new DateField('birthday', 'birthday'),
             (new DateTimeField('last_order_date', 'lastOrderDate'))->addFlags(new WriteProtected(Context::SYSTEM_SCOPE)),
             (new IntField('order_count', 'orderCount'))->addFlags(new WriteProtected(Context::SYSTEM_SCOPE)),
-            new CustomFields(),
+            (new CustomFields())->addFlags(new SearchRanking(SearchRanking::HIGH_SEARCH_RANKING)),
             (new StringField('legacy_password', 'legacyPassword'))->addFlags(new ReadProtected(SalesChannelApiSource::class, AdminApiSource::class)),
             (new StringField('legacy_encoder', 'legacyEncoder'))->addFlags(new ReadProtected(SalesChannelApiSource::class, AdminApiSource::class)),
             new ManyToOneAssociationField('group', 'customer_group_id', CustomerGroupDefinition::class, 'id', false),

--- a/src/Core/Content/Product/Aggregate/ProductManufacturer/ProductManufacturerDefinition.php
+++ b/src/Core/Content/Product/Aggregate/ProductManufacturer/ProductManufacturerDefinition.php
@@ -50,7 +50,7 @@ class ProductManufacturerDefinition extends EntityDefinition
             new StringField('link', 'link'),
             (new TranslatedField('name'))->addFlags(new SearchRanking(SearchRanking::HIGH_SEARCH_RANKING)),
             new TranslatedField('description'),
-            (new TranslatedField('customFields'))->addFlags(new SearchRanking(SearchRanking::HIGH_SEARCH_RANKING)),
+            (new TranslatedField('customFields'))->addFlags(new SearchRanking(SearchRanking::MIDDLE_SEARCH_RANKING)),
             new ManyToOneAssociationField('media', 'media_id', MediaDefinition::class, 'id', false),
             (new OneToManyAssociationField('products', ProductDefinition::class, 'product_manufacturer_id', 'id'))->addFlags(new RestrictDelete(), new ReverseInherited('manufacturer')),
             (new TranslationsAssociationField(ProductManufacturerTranslationDefinition::class, 'product_manufacturer_id'))->addFlags(new Required()),

--- a/src/Core/Content/Product/Aggregate/ProductManufacturer/ProductManufacturerDefinition.php
+++ b/src/Core/Content/Product/Aggregate/ProductManufacturer/ProductManufacturerDefinition.php
@@ -50,7 +50,7 @@ class ProductManufacturerDefinition extends EntityDefinition
             new StringField('link', 'link'),
             (new TranslatedField('name'))->addFlags(new SearchRanking(SearchRanking::HIGH_SEARCH_RANKING)),
             new TranslatedField('description'),
-            new TranslatedField('customFields'),
+            (new TranslatedField('customFields'))->addFlags(new SearchRanking(SearchRanking::HIGH_SEARCH_RANKING)),
             new ManyToOneAssociationField('media', 'media_id', MediaDefinition::class, 'id', false),
             (new OneToManyAssociationField('products', ProductDefinition::class, 'product_manufacturer_id', 'id'))->addFlags(new RestrictDelete(), new ReverseInherited('manufacturer')),
             (new TranslationsAssociationField(ProductManufacturerTranslationDefinition::class, 'product_manufacturer_id'))->addFlags(new Required()),

--- a/src/Core/Content/Product/ProductDefinition.php
+++ b/src/Core/Content/Product/ProductDefinition.php
@@ -173,7 +173,7 @@ class ProductDefinition extends EntityDefinition
             (new TranslatedField('metaTitle'))->addFlags(new Inherited()),
             (new TranslatedField('packUnit'))->addFlags(new Inherited()),
             (new TranslatedField('packUnitPlural'))->addFlags(new Inherited()),
-            (new TranslatedField('customFields'))->addFlags(new Inherited(), new SearchRanking(SearchRanking::HIGH_SEARCH_RANKING)),
+            (new TranslatedField('customFields'))->addFlags(new Inherited(), new SearchRanking(SearchRanking::MIDDLE_SEARCH_RANKING)),
 
             // associations
             new ParentAssociationField(self::class, 'id'),

--- a/src/Core/Content/Product/ProductDefinition.php
+++ b/src/Core/Content/Product/ProductDefinition.php
@@ -173,7 +173,7 @@ class ProductDefinition extends EntityDefinition
             (new TranslatedField('metaTitle'))->addFlags(new Inherited()),
             (new TranslatedField('packUnit'))->addFlags(new Inherited()),
             (new TranslatedField('packUnitPlural'))->addFlags(new Inherited()),
-            (new TranslatedField('customFields'))->addFlags(new Inherited()),
+            (new TranslatedField('customFields'))->addFlags(new Inherited(), new SearchRanking(SearchRanking::HIGH_SEARCH_RANKING)),
 
             // associations
             new ParentAssociationField(self::class, 'id'),


### PR DESCRIPTION
### 1. Why is this change necessary?

It gives possibility to search by Custom Fields in Administration.

### 2. What does this change do, exactly?

It adds `SearchRanking` flag which is used by `EntityScoreQueryBuilder` to build queries based on the Term provided.

### 3. Describe each step to reproduce the issue or behaviour.

Example: Please create i.e. a product with Custom Field. Go to search field in Administration, fill in the Custom Field value (or part) and hit ENTER. The product should be returned in search results. It works for Products, Manufacturers and Customers in Administration only.

### 4. Please link to the relevant issues (if any).

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/master/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
