### PR TITLE
NEXT-10858 - Extract value constraints for line item custom field rule, allow empty bool value.

### DIFF
--- a/changelog/_unreleased/2020-09-17-improve-line-item-custom-field-rule-execution.md
+++ b/changelog/_unreleased/2020-09-17-improve-line-item-custom-field-rule-execution.md
@@ -1,0 +1,9 @@
+---
+title: Improve line item custom field rule execution
+issue: NEXT-10858
+author: Uwe Kleinmann
+author_email: u.kleinmann@kellerkinder.de
+author_github: @kleinmann
+---
+# Core
+* Added support for unchecked boolean custom fields to line item custom field rule condition validation and execution.

--- a/src/Core/Checkout/Test/Cart/Rule/LineItemCustomFieldRuleTest.php
+++ b/src/Core/Checkout/Test/Cart/Rule/LineItemCustomFieldRuleTest.php
@@ -3,7 +3,11 @@
 namespace Shopware\Core\Checkout\Test\Cart\Rule;
 
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Checkout\Cart\LineItem\LineItem;
 use Shopware\Core\Checkout\Cart\Rule\LineItemCustomFieldRule;
+use Shopware\Core\Checkout\Cart\Rule\LineItemScope;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\System\SalesChannel\SalesChannelContext;
 
 /**
  * @group rules
@@ -15,9 +19,15 @@ class LineItemCustomFieldRuleTest extends TestCase
      */
     private $rule;
 
+    /** @var SalesChannelContext */
+    private $salesChannelContext;
+
     protected function setUp(): void
     {
         $this->rule = new LineItemCustomFieldRule();
+
+        $this->salesChannelContext = $this->getMockBuilder(SalesChannelContext::class)->disableOriginalConstructor()->getMock();
+        $this->salesChannelContext->method('getContext')->willReturn(Context::createDefaultContext());
     }
 
     public function testGetName(): void
@@ -34,5 +44,71 @@ class LineItemCustomFieldRuleTest extends TestCase
         static::assertArrayHasKey('renderedFieldValue', $ruleConstraints, 'Rule Constraint renderedFieldValue is not defined');
         static::assertArrayHasKey('selectedField', $ruleConstraints, 'Rule Constraint selectedField is not defined');
         static::assertArrayHasKey('selectedFieldSet', $ruleConstraints, 'Rule Constraint selectedFieldSet is not defined');
+    }
+
+    public function testBooleanCustomFieldFalseWithNoValue(): void
+    {
+        $this->setupRule('custom_test', false);
+        $scope = new LineItemScope($this->getLineItem(), $this->salesChannelContext);
+        static::assertTrue($this->rule->match($scope));
+    }
+
+    public function testBooleanCustomFieldFalse(): void
+    {
+        $this->setupRule('custom_test', false);
+        $scope = new LineItemScope($this->getLineItem(['custom_test' => false]), $this->salesChannelContext);
+        static::assertTrue($this->rule->match($scope));
+    }
+
+    public function testBooleanCustomFieldNull(): void
+    {
+        $this->setupRule('custom_test', null);
+        $scope = new LineItemScope($this->getLineItem(['custom_test' => false]), $this->salesChannelContext);
+        static::assertTrue($this->rule->match($scope));
+    }
+
+    public function testBooleanCustomFieldInvalid(): void
+    {
+        $this->setupRule('custom_test', false);
+        $scope = new LineItemScope($this->getLineItem(['custom_test' => true]), $this->salesChannelContext);
+        static::assertFalse($this->rule->match($scope));
+    }
+
+    public function testStringCustomField(): void
+    {
+        $this->setupRule('custom_test', 'my_test_value');
+        $scope = new LineItemScope($this->getLineItem(['custom_test' => 'my_test_value']), $this->salesChannelContext);
+        static::assertTrue($this->rule->match($scope));
+    }
+
+    public function testStringCustomFieldInvalid(): void
+    {
+        $this->setupRule('custom_test', 'my_test_value');
+        $scope = new LineItemScope($this->getLineItem(['custom_test' => 'my_invalid_value']), $this->salesChannelContext);
+        static::assertFalse($this->rule->match($scope));
+    }
+
+    private function getLineItem(array $customFields = []): LineItem
+    {
+        $lineItem = new LineItem('', LineItem::PRODUCT_LINE_ITEM_TYPE);
+
+        $lineItem
+            ->setPayloadValue('customFields', $customFields);
+
+        return $lineItem;
+    }
+
+    private function setupRule(string $customFieldName, $customFieldValue): void
+    {
+        $this->rule->assign(
+            [
+                'operator' => $this->rule::OPERATOR_EQ,
+                'renderedField' => [
+                    'type' => 'bool',
+                    'name' => $customFieldName,
+                ],
+                'renderedFieldValue' => $customFieldValue,
+            ]
+        );
     }
 }

--- a/src/Core/Content/Rule/RuleValidator.php
+++ b/src/Core/Content/Rule/RuleValidator.php
@@ -140,6 +140,8 @@ class RuleValidator implements EventSubscriberInterface
         }
 
         $value = $this->getConditionValue($condition, $payload);
+        $ruleInstance->assign($value);
+
         $this->validateConsistence(
             $ruleInstance->getConstraints(),
             $value,

--- a/src/Core/System/CustomField/CustomFieldTypes.php
+++ b/src/Core/System/CustomField/CustomFieldTypes.php
@@ -12,6 +12,7 @@ final class CustomFieldTypes
     public const TEXT = 'text';
     public const HTML = 'html';
     public const SELECT = 'select';
+    public const SWITCH = 'switch';
 
     private function __construct()
     {


### PR DESCRIPTION
<!--
Thank you for contributing to the Shopware BoostDay! Please fill out this description template to help us to process your pull request.

Important! Please make sure your PRs follows the following structure:
-My commit(s) look like this "next-XXXX/my-commit-massage" (next-xxxx is found in the title of the issue)
-My title looks something like this "NEXT-XXXX - Issue name" (You can use the same Title as in the issue you're dealing with)

Please make sure to fulfil our general contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/contribution/contribution-guideline?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->


### 1. What does this change do, exactly?
Fix handling of boolean custom fields in the `LineItemCustomFieldRule` by adding fallback values for the null-initialization in the rule builder and removing `NotEmpty` constraints for boolean fields in the rule condition.

See [this short video](https://vimeo.com/458984611/87e9e29df8) detailing the solution.

Fixes #115.

### 2. Describe each step to reproduce the issue or behaviour.
* Have custom field of boolean type (checkbox or switch)
* Add a line item custom field rule condition for this field and leave the checkbox unchecked
* Try to save the rule and be sad about the error message stating that a value is required

If you somehow manage to circumvent that (e.g. add the rule via the database directly), but are using the default null value from the administration (yes, a bit contrived):
* Use the rule for a promotion
* Try to add the promotion in the cart
* Be sad that the promotion is not available

### 3. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/master/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
