### PR TITLE
NEXT-10844 - Allow creating documents without order reference

### DIFF
--- a/changelog/_unreleased/2020-09-17-allow-creating-documents-without-order-reference.md
+++ b/changelog/_unreleased/2020-09-17-allow-creating-documents-without-order-reference.md
@@ -1,0 +1,12 @@
+---
+title: Allow creating documents without order reference
+issue: NEXT-10844
+author: Sven Münnich
+author_email: sven.muennich@pickware.de 
+author_github: svenmuennich
+---
+# Core
+* Changes `DocumentGeneratorInterface::supports()` to expect a single `string` argument `$documentType` and return a `bool` indicating whether the passed document type is supported.
+* Changes `DocumentGeneratorInterface::generate()` to remove the first argument `$order`.
+* Adds new class `AbstractOrderDocumentGenerator` simplifying implementing generators for order documents.
+* Fixes generation of documents in landscape orientation if they are based on `@Framework/documents/base.html.twig`.

--- a/src/Core/Checkout/Document/DocumentConfiguration.php
+++ b/src/Core/Checkout/Document/DocumentConfiguration.php
@@ -7,16 +7,6 @@ use Shopware\Core\Framework\Struct\Struct;
 class DocumentConfiguration extends Struct
 {
     /**
-     * @var bool|null
-     */
-    protected $displayPrices;
-
-    /**
-     * @var array|null
-     */
-    protected $logo;
-
-    /**
      * @var string|null
      */
     protected $filenamePrefix;
@@ -40,116 +30,6 @@ class DocumentConfiguration extends Struct
      * @var string
      */
     protected $pageSize;
-
-    /**
-     * @var bool|null
-     */
-    protected $displayFooter;
-
-    /**
-     * @var bool|null
-     */
-    protected $displayHeader;
-
-    /**
-     * @var bool|null
-     */
-    protected $displayLineItems;
-
-    /**
-     * @var bool|null
-     */
-    protected $displayLineItemPosition;
-
-    /**
-     * @var int|null
-     */
-    protected $itemsPerPage;
-
-    /**
-     * @var bool|null
-     */
-    protected $displayPageCount;
-
-    /**
-     * @var bool|null
-     */
-    protected $displayCompanyAddress;
-
-    /**
-     * @var string|null
-     */
-    protected $title;
-
-    /**
-     * @var string|null
-     */
-    protected $companyAddress;
-
-    /**
-     * @var string|null
-     */
-    protected $companyName;
-
-    /**
-     * @var string|null
-     */
-    protected $companyEmail;
-
-    /**
-     * @var string|null
-     */
-    protected $companyUrl;
-
-    /**
-     * @var string|null
-     */
-    protected $taxNumber;
-
-    /**
-     * @var string|null
-     */
-    protected $taxOffice;
-
-    /**
-     * @var string|null
-     */
-    protected $vatId;
-
-    /**
-     * @var string|null
-     */
-    protected $bankName;
-
-    /**
-     * @var string|null
-     */
-    protected $bankIban;
-
-    /**
-     * @var string|null
-     */
-    protected $bankBic;
-
-    /**
-     * @var string|null
-     */
-    protected $placeOfJurisdiction;
-
-    /**
-     * @var string|null
-     */
-    protected $placeOfFulfillment;
-
-    /**
-     * @var string|null
-     */
-    protected $executiveDirector;
-
-    /**
-     * @var array
-     */
-    protected $custom = [];
 
     public function __set($name, $value)
     {

--- a/src/Core/Checkout/Document/DocumentConfigurationFactory.php
+++ b/src/Core/Checkout/Document/DocumentConfigurationFactory.php
@@ -40,12 +40,12 @@ class DocumentConfigurationFactory
         foreach ($additionalConfigArray as $key => $value) {
             if ($value !== null) {
                 if ($key === 'custom' && \is_array($value)) {
-                    $baseConfig->__set('custom', array_merge($baseConfig->__get('custom'), $value));
+                    $baseConfig->custom = array_merge($baseConfig->custom ?? [], $value);
                 } elseif (strncmp($key, 'custom.', 7) === 0) {
                     $customKey = mb_substr($key, 7);
-                    $baseConfig->__set('custom', array_merge($baseConfig->__get('custom'), [$customKey => $value]));
+                    $baseConfig->custom = array_merge($baseConfig->custom ?? [], [$customKey => $value]);
                 } else {
-                    $baseConfig->__set($key, $value);
+                    $baseConfig->$key = $value;
                 }
             }
         }

--- a/src/Core/Checkout/Document/DocumentGenerator/AbstractOrderDocumentGenerator.php
+++ b/src/Core/Checkout/Document/DocumentGenerator/AbstractOrderDocumentGenerator.php
@@ -1,0 +1,70 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Checkout\Document\DocumentGenerator;
+
+use Shopware\Core\Checkout\Document\DocumentConfiguration;
+use Shopware\Core\Checkout\Document\Exception\DocumentGenerationException;
+use Shopware\Core\Checkout\Document\Twig\DocumentTemplateRenderer;
+use Shopware\Core\Checkout\Order\OrderEntity;
+use Shopware\Core\Framework\Context;
+use Twig\Error\Error;
+
+abstract class AbstractOrderDocumentGenerator
+{
+    /**
+     * @var string
+     */
+    private $rootDir;
+
+    /**
+     * @var DocumentTemplateRenderer
+     */
+    private $documentTemplateRenderer;
+
+    public function __construct(DocumentTemplateRenderer $documentTemplateRenderer, string $rootDir)
+    {
+        $this->documentTemplateRenderer = $documentTemplateRenderer;
+        $this->rootDir = $rootDir;
+    }
+
+    /**
+     * @throws Error
+     * @throws DocumentGenerationException
+     */
+    public function generate(
+        DocumentConfiguration $config,
+        Context $context,
+        ?string $templatePath = null
+    ): string {
+        $order = $config->order;
+        if (!($order instanceof OrderEntity)) {
+            throw new DocumentGenerationException();
+        }
+
+        $defaultParameters = [
+            'config' => $config->jsonSerialize(),
+            'context' => $context,
+            'order' => $order,
+            'rootDir' => $this->rootDir,
+        ];
+        $parameters = array_merge($defaultParameters, $this->getExtraParameters($order, $context));
+
+        return $this->documentTemplateRenderer->render(
+            $templatePath ?? $this->getDefaultTemplate(),
+            $parameters,
+            $context,
+            $order->getSalesChannelId(),
+            $order->getLanguageId(),
+            $order->getLanguage()->getLocale()->getCode()
+        );
+    }
+
+    public function getFileName(DocumentConfiguration $config): string
+    {
+        return $config->getFilenamePrefix() . $config->getDocumentNumber() . $config->getFilenameSuffix();
+    }
+
+    abstract protected function getExtraParameters(OrderEntity $order, Context $context): array;
+
+    abstract protected function getDefaultTemplate(): string;
+}

--- a/src/Core/Checkout/Document/DocumentGenerator/DocumentGeneratorInterface.php
+++ b/src/Core/Checkout/Document/DocumentGenerator/DocumentGeneratorInterface.php
@@ -3,19 +3,13 @@
 namespace Shopware\Core\Checkout\Document\DocumentGenerator;
 
 use Shopware\Core\Checkout\Document\DocumentConfiguration;
-use Shopware\Core\Checkout\Order\OrderEntity;
 use Shopware\Core\Framework\Context;
 
 interface DocumentGeneratorInterface
 {
-    public function supports(): string;
+    public function supports(string $documentType): bool;
 
-    public function generate(
-        OrderEntity $order,
-        DocumentConfiguration $config,
-        Context $context,
-        ?string $templatePath = null
-    ): string;
+    public function generate(DocumentConfiguration $config, Context $context, ?string $templatePath = null): string;
 
     public function getFileName(DocumentConfiguration $config): string;
 }

--- a/src/Core/Checkout/Document/DocumentGenerator/DocumentGeneratorRegistry.php
+++ b/src/Core/Checkout/Document/DocumentGenerator/DocumentGeneratorRegistry.php
@@ -19,11 +19,9 @@ class DocumentGeneratorRegistry
     public function hasGenerator(string $documentType): bool
     {
         foreach ($this->documentGenerators as $documentGenerator) {
-            if ($documentGenerator->supports() !== $documentType) {
-                continue;
+            if ($documentGenerator->supports($documentType)) {
+                return true;
             }
-
-            return true;
         }
 
         return false;
@@ -35,11 +33,9 @@ class DocumentGeneratorRegistry
     public function getGenerator(string $documentType): DocumentGeneratorInterface
     {
         foreach ($this->documentGenerators as $documentGenerator) {
-            if ($documentGenerator->supports() !== $documentType) {
-                continue;
+            if ($documentGenerator->supports($documentType)) {
+                return $documentGenerator;
             }
-
-            return $documentGenerator;
         }
 
         throw new InvalidDocumentGeneratorTypeException($documentType);
@@ -48,11 +44,9 @@ class DocumentGeneratorRegistry
     public function getGenerators(string $documentType): \Generator
     {
         foreach ($this->documentGenerators as $documentGenerator) {
-            if ($documentGenerator->supports() !== $documentType) {
-                continue;
+            if ($documentGenerator->supports($documentType)) {
+                yield $documentGenerator;
             }
-
-            yield $documentGenerator;
         }
     }
 }

--- a/src/Core/Checkout/Document/DocumentGenerator/InvoiceGenerator.php
+++ b/src/Core/Checkout/Document/DocumentGenerator/InvoiceGenerator.php
@@ -2,69 +2,26 @@
 
 namespace Shopware\Core\Checkout\Document\DocumentGenerator;
 
-use Shopware\Core\Checkout\Document\DocumentConfiguration;
-use Shopware\Core\Checkout\Document\DocumentConfigurationFactory;
-use Shopware\Core\Checkout\Document\Twig\DocumentTemplateRenderer;
 use Shopware\Core\Checkout\Order\OrderEntity;
 use Shopware\Core\Framework\Context;
-use Twig\Error\Error;
 
-class InvoiceGenerator implements DocumentGeneratorInterface
+class InvoiceGenerator extends AbstractOrderDocumentGenerator implements DocumentGeneratorInterface
 {
-    public const DEFAULT_TEMPLATE = '@Framework/documents/invoice.html.twig';
     public const INVOICE = 'invoice';
+    public const DEFAULT_TEMPLATE = '@Framework/documents/invoice.html.twig';
 
-    /**
-     * @var string
-     */
-    private $rootDir;
-
-    /**
-     * @var DocumentTemplateRenderer
-     */
-    private $documentTemplateRenderer;
-
-    public function __construct(DocumentTemplateRenderer $documentTemplateRenderer, string $rootDir)
+    public function supports(string $documentType): bool
     {
-        $this->rootDir = $rootDir;
-        $this->documentTemplateRenderer = $documentTemplateRenderer;
+        return $documentType === self::INVOICE;
     }
 
-    public function supports(): string
+    protected function getExtraParameters(OrderEntity $order, Context $context): array
     {
-        return self::INVOICE;
+        return [];
     }
 
-    /**
-     * @throws Error
-     */
-    public function generate(
-        OrderEntity $order,
-        DocumentConfiguration $config,
-        Context $context,
-        ?string $templatePath = null
-    ): string {
-        $templatePath = $templatePath ?? self::DEFAULT_TEMPLATE;
-
-        $documentString = $this->documentTemplateRenderer->render(
-            $templatePath,
-            [
-                'order' => $order,
-                'config' => DocumentConfigurationFactory::mergeConfiguration($config, new DocumentConfiguration())->jsonSerialize(),
-                'rootDir' => $this->rootDir,
-                'context' => $context,
-            ],
-            $context,
-            $order->getSalesChannelId(),
-            $order->getLanguageId(),
-            $order->getLanguage()->getLocale()->getCode()
-        );
-
-        return $documentString;
-    }
-
-    public function getFileName(DocumentConfiguration $config): string
+    protected function getDefaultTemplate(): string
     {
-        return $config->getFilenamePrefix() . $config->getDocumentNumber() . $config->getFilenameSuffix();
+        return self::DEFAULT_TEMPLATE;
     }
 }

--- a/src/Core/Checkout/Test/Document/DocumentType/InvoiceServiceTest.php
+++ b/src/Core/Checkout/Test/Document/DocumentType/InvoiceServiceTest.php
@@ -109,13 +109,10 @@ class InvoiceServiceTest extends TestCase
                 'displayHeader' => true,
             ]
         );
+        $documentConfiguration->order = $order;
         $context = Context::createDefaultContext();
 
-        $processedTemplate = $invoiceService->generate(
-            $order,
-            $documentConfiguration,
-            $context
-        );
+        $processedTemplate = $invoiceService->generate($documentConfiguration, $context);
 
         static::assertStringContainsString('<html>', $processedTemplate);
         static::assertStringContainsString('</html>', $processedTemplate);

--- a/src/Core/Framework/Resources/views/documents/base.html.twig
+++ b/src/Core/Framework/Resources/views/documents/base.html.twig
@@ -29,7 +29,7 @@
             {#{% if config.title %}#}
             <title>{% block document_title_tag %}{% endblock %}</title>
             {#{% endif %}#}
-            {% if config.custom.pageOrientation == 'landscape' %}
+            {% if config.pageOrientation == 'landscape' %}
                 {% sw_include '@Framework/documents/style_base_landscape.css.twig' %}
             {% else %}
                 {% sw_include '@Framework/documents/style_base_portrait.css.twig' %}


### PR DESCRIPTION
### 1. What does this change do, exactly?
The main change of this PR is removing the `$order` argument from `DocumentGeneratorInterface::generate()` to allow creating generators for documents unrelated to orders. The `OrderEntity` is added to the config instead.

On the way I changed several other things:
* Fixed generation of order documents in landscape orientation.
* Removed unnecessary properties from `DocumentConfiguration`.
* Added an `AbstractOrderDocumentGenerator` and based all existing document generators on it to get rid of some boilerplate code.
* Changed `DocumentGeneratorInterface::supports()` to expect a `string` argument and return a `bool`.

### 2. Describe each step to reproduce the issue or behaviour.
Just try to create a document without having an order reference.

### 3. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/master/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
