### PR TITLE
NEXT-7072 - Search for mail templates

### DIFF
--- a/changelog/_unreleased/2020-09-17-search-for-mail-templates.md
+++ b/changelog/_unreleased/2020-09-17-search-for-mail-templates.md
@@ -1,0 +1,14 @@
+---
+title: Search for mail templates
+issue: NEXT-7072
+author: Sebastian Hölscher
+author_email: s.hoelscher@shopware.com 
+author_github: @HoelShare
+---
+# Administration
+* Added new optional prop `searchTerm` to `sw-mail-header-footer-list/index.js`
+* Set boolean `disableRouteParams` default to true in `sw-mail-header-footer-list/index.js`
+* Added new optional prop `searchTerm` to `sw-mail-template-list/index.js`
+* Set boolean `disableRouteParams` default to true in `sw-mail-template-list/index.js`
+* Added new String data prop `searchTerm` to `sw-mail-template-index/index.js`
+* Removed the `listing` mixin from `sw-mail-template-index/index.js`

--- a/src/Administration/Resources/app/administration/src/module/sw-mail-template/component/sw-mail-header-footer-list/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-mail-template/component/sw-mail-header-footer-list/index.js
@@ -12,17 +12,34 @@ Component.register('sw-mail-header-footer-list', {
         Mixin.getByName('listing')
     ],
 
+    props: {
+        searchTerm: {
+            type: String,
+            required: false,
+            default: ''
+        }
+    },
+
     data() {
         return {
             mailHeaderFooters: null,
             showDeleteModal: null,
-            isLoading: false
+            isLoading: false,
+            disableRouteParams: true
         };
     },
 
     computed: {
         mailHeaderFooterRepository() {
             return this.repositoryFactory.create('mail_header_footer');
+        }
+    },
+
+    watch: {
+        searchTerm: {
+            handler(value) {
+                this.onSearch(value);
+            }
         }
     },
 
@@ -42,7 +59,8 @@ Component.register('sw-mail-header-footer-list', {
             this.isLoading = true;
             this.mailHeaderFooters = null;
             const criteria = new Criteria(this.page, this.limit);
-            criteria.addAssociation('salesChannels');
+            criteria.setTerm(this.term)
+                    .addAssociation('salesChannels');
 
             this.mailHeaderFooterRepository.search(criteria, Shopware.Context.api).then((items) => {
                 this.total = items.total;

--- a/src/Administration/Resources/app/administration/src/module/sw-mail-template/component/sw-mail-template-list/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-mail-template/component/sw-mail-template-list/index.js
@@ -13,10 +13,19 @@ Component.register('sw-mail-template-list', {
         Mixin.getByName('notification')
     ],
 
+    props: {
+        searchTerm: {
+            type: String,
+            required: false,
+            default: ''
+        }
+    },
+
     data() {
         return {
             mailTemplates: null,
             showDeleteModal: null,
+            disableRouteParams: true,
             isLoading: false
         };
     },
@@ -27,12 +36,21 @@ Component.register('sw-mail-template-list', {
         }
     },
 
+    watch: {
+        searchTerm: {
+            handler(value) {
+                this.onSearch(value);
+            }
+        }
+    },
+
     methods: {
         getList() {
             this.isLoading = true;
             this.mailTemplates = null;
 
             const criteria = new Criteria(this.page, this.limit);
+            criteria.setTerm(this.term)
 
             criteria.getAssociation('salesChannels')
                 .setLimit(10)

--- a/src/Administration/Resources/app/administration/src/module/sw-mail-template/page/sw-mail-template-index/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-mail-template/page/sw-mail-template-index/index.js
@@ -1,17 +1,19 @@
 import template from './sw-mail-template-index.html.twig';
 
-const { Component, Mixin } = Shopware;
+const { Component } = Shopware;
 
 Component.register('sw-mail-template-index', {
     template,
 
-    mixins: [
-        Mixin.getByName('listing')
-    ],
-
     metaInfo() {
         return {
             title: this.$createTitle()
+        };
+    },
+
+    data() {
+        return {
+           searchTerm: ''
         };
     },
 
@@ -20,6 +22,9 @@ Component.register('sw-mail-template-index', {
             Shopware.State.commit('context/setApiLanguageId', languageId);
             this.$refs.mailHeaderFooterList.getList();
             this.$refs.mailTemplateList.getList();
-        }
+        },
+        onSearch(value) {
+            this.searchTerm = value;
+        },
     }
 });

--- a/src/Administration/Resources/app/administration/src/module/sw-mail-template/page/sw-mail-template-index/sw-mail-template-index.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-mail-template/page/sw-mail-template-index/sw-mail-template-index.html.twig
@@ -3,7 +3,6 @@
         {% block sw_mail_templates_list_search_bar %}
             <template #search-bar>
                 <sw-search-bar initialSearchType="mail_template"
-                               :initialSearch="term"
                                @search="onSearch">
                 </sw-search-bar>
             </template>
@@ -57,9 +56,9 @@
             <template #content>
                 <sw-card-view>
                     {% block sw_mail_template_list_content_card %}
-                        <sw-mail-template-list ref="mailTemplateList"></sw-mail-template-list>
+                        <sw-mail-template-list ref="mailTemplateList" :searchTerm="searchTerm"></sw-mail-template-list>
 
-                        <sw-mail-header-footer-list ref="mailHeaderFooterList"></sw-mail-header-footer-list>
+                        <sw-mail-header-footer-list ref="mailHeaderFooterList" :searchTerm="searchTerm"></sw-mail-header-footer-list>
                     {% endblock %}
                 </sw-card-view>
             </template>


### PR DESCRIPTION
### 1. What does this change do, exactly?
It wasn't possible to search for mail templates in the administration.
Fixes #85 

### 2. Describe each step to reproduce the issue or behaviour.
Go to settings > Email Templates. Try searching for some templates.

### 3. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/master/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
