### PR TITLE
NEXT-9105 - Discount: Wrong payment snippet in checkout

### DIFF
--- a/src/Core/Checkout/Promotion/Cart/Error/PromotionNotEligibleError.php
+++ b/src/Core/Checkout/Promotion/Cart/Error/PromotionNotEligibleError.php
@@ -42,6 +42,11 @@ class PromotionNotEligibleError extends Error
         return self::KEY;
     }
 
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
     public function blockOrder(): bool
     {
         return false;

--- a/src/Core/Checkout/Promotion/Cart/PromotionCartAddedInformationError.php
+++ b/src/Core/Checkout/Promotion/Cart/PromotionCartAddedInformationError.php
@@ -40,6 +40,11 @@ class PromotionCartAddedInformationError extends Error
         return self::KEY;
     }
 
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
     public function getParameters(): array
     {
         return [

--- a/src/Core/Checkout/Promotion/Cart/PromotionCartDeletedInformationError.php
+++ b/src/Core/Checkout/Promotion/Cart/PromotionCartDeletedInformationError.php
@@ -35,6 +35,11 @@ class PromotionCartDeletedInformationError extends Error
         return self::KEY;
     }
 
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
     public function getParameters(): array
     {
         return [

--- a/src/Storefront/Resources/views/storefront/component/checkout/cart-alerts.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/checkout/cart-alerts.html.twig
@@ -1,7 +1,7 @@
 {% block component_checkout_cart_alerts %}
     {% block component_checkout_cart_alerts_notices %}
         {% for error in page.cart.errors.notices %}
-            {% set snippetName = "error.#{error.messageKey}" %}
+            {% set snippetName = "checkout.#{error.messageKey}" %}
 
             {% sw_include '@Storefront/storefront/utilities/alert.html.twig' with {
                 type: "info",


### PR DESCRIPTION
### 1. Why is this change necessary?
Display the translated notice instead of snippet key

### 2. What does this change do, exactly?
Display proper text instead of shippet:
![image](https://user-images.githubusercontent.com/71152566/93484535-4e789e80-f902-11ea-9476-82782c097fb3.png)


### 3. Describe each step to reproduce the issue or behaviour.
Steps to reproduce:

1. Setup shopping cart rule with a. payment type condition
2. Create a discount applied when rule is valid
3. Add item to shopping cart, select payment method
(copied from original ticket https://github.com/shopwareBoostDay/platform/issues/40)

### 4. Please link to the relevant issues (if any).

https://github.com/shopwareBoostDay/platform/issues/40

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/master/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [X] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.
