### PR TITLE
NEXT-9360 - add missing order delivery state transitions

### DIFF
--- a/changelog/_unreleased/2020-09-17-add-missing-order-delivery-state-transitions.md
+++ b/changelog/_unreleased/2020-09-17-add-missing-order-delivery-state-transitions.md
@@ -1,0 +1,9 @@
+---
+title:              Add missing order delivery state transitions
+issue:              NEXT-9360
+author:             Jochen Manz
+author_email:       jochen.manz@gmx.de
+author_github:      @jochenmanz
+---
+# Core
+* Added transitions from all order delivery states back to the state open.

--- a/src/Core/Migration/Migration1600349343AddDeliveryStateTransitions.php
+++ b/src/Core/Migration/Migration1600349343AddDeliveryStateTransitions.php
@@ -1,0 +1,81 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Migration;
+
+use Doctrine\DBAL\Connection;
+use Shopware\Core\Defaults;
+use Shopware\Core\Framework\Migration\MigrationStep;
+use Shopware\Core\Framework\Uuid\Uuid;
+
+class Migration1600349343AddDeliveryStateTransitions extends MigrationStep
+{
+    public function getCreationTimestamp(): int
+    {
+        return 1600349342;
+    }
+
+    public function update(Connection $connection): void
+    {
+        $stateMachineId = $this->fetchOrderDeliveryStateId($connection);
+        $openStateId = $this->fetchOpenOrderDeliveryStateId($connection);
+        $missingStates = $this->fetchMissingOrderDeliveryStates($connection, $stateMachineId);
+
+        foreach ($missingStates as $missingState) {
+            $connection->insert(
+                'state_machine_transition',
+                [
+                    'id' => Uuid::randomBytes(),
+                    'action_name' => 'reopen',
+                    'state_machine_id' => $stateMachineId,
+                    'from_state_id' => $missingState,
+                    'to_state_id' => $openStateId,
+                    'created_at' => (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT),
+                ]
+            );
+        }
+    }
+
+    public function updateDestructive(Connection $connection): void
+    {
+        // implement update destructive
+    }
+
+    private function fetchOrderDeliveryStateId(Connection $connection): string
+    {
+        return $connection->fetchColumn('SELECT id FROM state_machine WHERE technical_name = :technical_name', [
+            ':technical_name' => 'order_delivery.state',
+        ]);
+    }
+
+    private function fetchOpenOrderDeliveryStateId(Connection $connection): string
+    {
+        return $connection->fetchColumn('SELECT initial_state_id FROM state_machine WHERE technical_name = :technical_name', [
+            ':technical_name' => 'order_delivery.state',
+        ]);
+    }
+
+    private function fetchMissingOrderDeliveryStates(Connection $connection, string $stateMachineId): array
+    {
+        $allStates = $connection->fetchAll('SELECT action_name, from_state_id, to_state_id FROM state_machine_transition WHERE state_machine_id = :id', [
+            ':id' => $stateMachineId,
+        ]);
+
+        $reopenStates = array_filter($allStates, static function (array $state) {
+            return $state['action_name'] === 'reopen';
+        });
+
+        $missingStates = array_filter($allStates, static function (array $state) use ($reopenStates) {
+            if (in_array($state['to_state_id'], array_column($reopenStates, 'from_state_id'), true)) {
+                return false;
+            }
+
+            if (in_array($state['to_state_id'], array_column($reopenStates, 'to_state_id'), true)) {
+                return false;
+            }
+
+            return true;
+        });
+
+        return array_unique(array_column($missingStates, 'to_state_id'));
+    }
+}

--- a/src/Core/Migration/Migration1600349343AddDeliveryStateTransitions.php
+++ b/src/Core/Migration/Migration1600349343AddDeliveryStateTransitions.php
@@ -11,7 +11,7 @@ class Migration1600349343AddDeliveryStateTransitions extends MigrationStep
 {
     public function getCreationTimestamp(): int
     {
-        return 1600349342;
+        return 1600349343;
     }
 
     public function update(Connection $connection): void


### PR DESCRIPTION
<!--
Thank you for contributing to the Shopware BoostDay! Please fill out this description template to help us to process your pull request.

Important! Please make sure your PRs follows the following structure:
-My commit(s) look like this "next-XXXX/my-commit-massage" (next-xxxx is found in the title of the issue)
-My title looks something like this "NEXT-XXXX - Issue name" (You can use the same Title as in the issue you're dealing with)

Please make sure to fulfil our general contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/contribution/contribution-guideline?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->


### 1. What does this change do, exactly?
Add's state transitions from all order delivery states back to open.

### 2. Describe each step to reproduce the issue or behaviour.


### 3. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/master/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.
