### PR TITLE
NEXT-7952 - Respect URL query parameters in non GET calls when building search criteria

### DIFF
--- a/changelog/_unreleased/2020-09-17-allow-url-query-parameters-in-search-api-requests.md
+++ b/changelog/_unreleased/2020-09-17-allow-url-query-parameters-in-search-api-requests.md
@@ -6,12 +6,7 @@ author_email: 3203968+carstendietrich@users.noreply.github.com
 author_github: @carstendietrich
 ---
 # Core
-* Update `\Shopware\Core\Framework\DataAbstractionLayer\Search\RequestCriteriaBuilder::handleRequest`
+* Changed `\Shopware\Core\Framework\DataAbstractionLayer\Search\RequestCriteriaBuilder::handleRequest`
   to allow URL query parameters even if the HTTP method is not `GET`.
-  This allows for specifying params e.g. for limit via query params in the URL (`search/product?limit=10`).
-  If a key is specified both in the request body and in the URL query parameters then the one in the body will be used.
-  
-___
-# API
-*  
-___
+  This allows to specify search criteria e.g. for the limit via query parameters directly in the URL (`search/product?limit=10`).
+  If a criterion is specified both in the request body and in the URL query parameters, the criterion specified in the request body is used.

--- a/changelog/_unreleased/2020-09-17-allow-url-query-parameters-in-search-api-requests.md
+++ b/changelog/_unreleased/2020-09-17-allow-url-query-parameters-in-search-api-requests.md
@@ -1,0 +1,17 @@
+---
+title: Allow URL query parameters in POST /api/v{number}/search/{entity} requests
+issue: NEXT-7952
+author: Carsten Dietrich
+author_email: 3203968+carstendietrich@users.noreply.github.com
+author_github: @carstendietrich
+---
+# Core
+* Update `\Shopware\Core\Framework\DataAbstractionLayer\Search\RequestCriteriaBuilder::handleRequest`
+  to allow URL query parameters even if the HTTP method is not `GET`.
+  This allows for specifying params e.g. for limit via query params in the URL (`search/product?limit=10`).
+  If a key is specified both in the request body and in the URL query parameters then the one in the body will be used.
+  
+___
+# API
+*  
+___

--- a/src/Core/Framework/DataAbstractionLayer/Search/RequestCriteriaBuilder.php
+++ b/src/Core/Framework/DataAbstractionLayer/Search/RequestCriteriaBuilder.php
@@ -53,7 +53,7 @@ class RequestCriteriaBuilder
         if ($request->getMethod() === Request::METHOD_GET) {
             $criteria = $this->fromArray($request->query->all(), $criteria, $definition, $context, $request->attributes->getInt('version'));
         } else {
-            $params = array_merge($request->query->all(), $request->request->all());
+            $params = array_replace($request->query->all(), $request->request->all());
             $criteria = $this->fromArray($params, $criteria, $definition, $context, $request->attributes->getInt('version'));
         }
 

--- a/src/Core/Framework/DataAbstractionLayer/Search/RequestCriteriaBuilder.php
+++ b/src/Core/Framework/DataAbstractionLayer/Search/RequestCriteriaBuilder.php
@@ -53,7 +53,8 @@ class RequestCriteriaBuilder
         if ($request->getMethod() === Request::METHOD_GET) {
             $criteria = $this->fromArray($request->query->all(), $criteria, $definition, $context, $request->attributes->getInt('version'));
         } else {
-            $criteria = $this->fromArray($request->request->all(), $criteria, $definition, $context, $request->attributes->getInt('version'));
+            $params = array_merge($request->query->all(), $request->request->all());
+            $criteria = $this->fromArray($params, $criteria, $definition, $context, $request->attributes->getInt('version'));
         }
 
         return $criteria;

--- a/src/Core/Framework/Test/DataAbstractionLayer/Search/RequestCriteriaBuilderTest.php
+++ b/src/Core/Framework/Test/DataAbstractionLayer/Search/RequestCriteriaBuilderTest.php
@@ -146,4 +146,43 @@ class RequestCriteriaBuilderTest extends TestCase
         static::assertCount(1, $sorting);
         static::assertEquals('_score', $sorting[0]->getField());
     }
+
+    public function testURLQueryParametersAreRespectedInPOSTRequests(): void
+    {
+        $request = new Request(['limit' => 11], [], [], [], []);
+        $request->setMethod(Request::METHOD_POST);
+
+        $criteria = $this->requestCriteriaBuilder->handleRequest(
+            $request,
+            new Criteria(),
+            $this->getContainer()->get(ProductDefinition::class),
+            Context::createDefaultContext()
+        );
+
+        static::assertEquals(11, $criteria->getLimit());
+    }
+
+    public function testQueryAndRequestParamsAreMerged(): void
+    {
+        $body = [
+            'limit' => 7,
+            'sort' => [
+                [
+                    'field' => '_score',
+                ],
+            ],
+        ];
+        $request = new Request(['limit' => 11, 'page' => 2], $body, [], [], []);
+        $request->setMethod(Request::METHOD_POST);
+
+        $criteria = $this->requestCriteriaBuilder->handleRequest(
+            $request,
+            new Criteria(),
+            $this->getContainer()->get(ProductDefinition::class),
+            Context::createDefaultContext()
+        );
+
+        static::assertEquals(7, $criteria->getLimit());
+        static::assertEquals(7, $criteria->getOffset());
+    }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to the Shopware BoostDay! Please fill out this description template to help us to process your pull request.

Important! Please make sure your PRs follows the following structure:
-My commit(s) look like this "next-XXXX/my-commit-massage" (next-xxxx is found in the title of the issue)
-My title looks something like this "NEXT-XXXX - Issue name" (You can use the same Title as in the issue you're dealing with)

Please make sure to fulfil our general contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/contribution/contribution-guideline?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->


### 1. What does this change do, exactly?
Previously when sending a `POST` request to the API endpoints for searching, all query parameters like ?limit=20 were ignored.
You could only set those parameters within the `POST` body. After discussing with the core team I decided to take query parameters also into account for a more convenient API usage especially since the API already responded with links containing query parameters. Query params and request body params will now be merged, if specified both in query and in request the one in request wins.

Issue #74 will be resolved by this. See the conversation there for more details.

### 2. Describe each step to reproduce the issue or behaviour.
1. Start Shopware 6.3
1. Call `POST` `api/v3/search/product?limit=7&page=3` with an empty body
2. Check response, neither limit nor page was taken into account
3. Use body: `{ "limit": 11 }`
4. Limit are now taken into account

**after PR**
1. Start shopware using this PR
1. Call `POST` `api/v3/search/product?limit=7&page=3` with an empty body
1. Response will contain 7 results on page 3
1. Use body: `{ "limit": 11 }`
1. Response will contain 11 results on page 3


### 3. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/master/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
