### PR TITLE
NEXT-9322 - check that min purchase does not exceed max purchase

### DIFF
--- a/changelog/_unreleased/2020-09-17-validate-min-max-purchase-quantity.md
+++ b/changelog/_unreleased/2020-09-17-validate-min-max-purchase-quantity.md
@@ -1,0 +1,9 @@
+---
+title: Validate min max purchase quantity
+issue: NEXT-9322
+author: Max
+author_email: max@swk-web.com
+author_github: @aragon999
+---
+# Administration
+*  Added validation when saving a product, to check if the max purchase quantity exceeds the min purchase quantity

--- a/src/Administration/Resources/app/administration/src/module/sw-product/page/sw-product-detail/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/page/sw-product-detail/index.js
@@ -430,6 +430,14 @@ Component.register('sw-product-detail', {
         },
 
         onSave() {
+            if (!this.validateProductPurchase()) {
+                this.createNotificationError({
+                    message: this.$tc('sw-product.detail.errorMinMaxPurchase')
+                });
+
+                return;
+            }
+
             if (!this.productId) {
                 if (this.productNumberPreview === this.product.productNumber) {
                     this.numberRangeService.reserve('product').then((response) => {
@@ -438,6 +446,7 @@ Component.register('sw-product-detail', {
                     });
                 }
             }
+
 
             this.isSaveSuccessful = false;
 
@@ -636,6 +645,14 @@ Component.register('sw-product-detail', {
         onDuplicateFinish(duplicate) {
             this.cloning = false;
             this.$router.push({ name: 'sw.product.detail', params: { id: duplicate.id } });
+        },
+
+        validateProductPurchase() {
+            if (this.product.minPurchase >= this.product.maxPurchase) {
+                return false;
+            }
+
+            return true;
         }
     }
 });

--- a/src/Administration/Resources/app/administration/src/module/sw-product/snippet/de-DE.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/snippet/de-DE.json
@@ -195,7 +195,8 @@
       "tabCrossSelling": "Cross Selling",
       "messageSaveSuccess": "Das Produkt \"{name}\" wurde erfolgreich gespeichert.",
       "messageUploadSuccess": "{count} von {total} Dateien erfolgreich gespeichert.",
-      "messageSaveWarning": "Keine Änderung vorgenommen."
+      "messageSaveWarning": "Keine Änderung vorgenommen.",
+      "errorMinMaxPurchase": "Produkt konnte nicht gespeichert werden, die minimale Bestellmenge überschreitet die Maximalabnahme."
     },
     "mediaForm": {
       "errorHeadline": "Fehler",

--- a/src/Administration/Resources/app/administration/src/module/sw-product/snippet/en-GB.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/snippet/en-GB.json
@@ -195,7 +195,8 @@
       "tabProperties": "Property assignment",
       "messageSaveSuccess": "Product \"{name}\" has been saved.",
       "messageUploadSuccess": "{count} of {total} files saved.",
-      "messageSaveWarning": "No changes detected."
+      "messageSaveWarning": "No changes detected.",
+      "errorMinMaxPurchase": "Could not save product, the min purchase quantity is larger than max purchase quantity."
     },
     "mediaForm": {
       "errorHeadline": "Error",


### PR DESCRIPTION
### 1. Why is this change necessary?
One currently can save invalid combinations for the min and max purchase values. This PR prevents saving such combinations in the administration.

### 2. What does this change do, exactly?
Implement a validation before saving the product in the administration

### 3. Describe each step to reproduce the issue or behaviour.
Put for example 11 as min order quantity and 10 as max order quantity in a product and save it, it will work but the product in the storefront is kind of broken.

### 4. Please link to the relevant issues (if any).
Fixes #22

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/master/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
