### PR TITLE
NEXT-9121 - Redirect Maintenance

### DIFF
--- a/changelog/_unreleased/2020-09-17-maintenance-forward.md
+++ b/changelog/_unreleased/2020-09-17-maintenance-forward.md
@@ -1,0 +1,14 @@
+---
+title:              Fix maintenance page
+issue:              NEXT-9121
+author:             Sebastian König
+author_email:       s.koenig@tinect.de
+author_github:      @tinect
+---
+# Storefront
+*  Added auto reload to `Storefront/storefront/page/error/error-maintenance.html.twig` with new block `error_maintenance_script_reload`
+*  Added new method `shouldRedirectToShop` to `Shopware\Storefront\Framework\Routing\MaintenanceModeResolver`
+*  Added service `Shopware\Storefront\Framework\Routing\MaintenanceModeResolver` to `Shopware\Storefront\Controller\MaintenanceController\MaintenanceController`
+*  Added status code `HTTP_SERVICE_UNAVAILABLE` to result for active maintenance mode in `Shopware\Storefront\Controller\MaintenanceController\MaintenanceController`
+*  Added header `Retry-After` to result for active maintenance mode in `Shopware\Storefront\Controller\MaintenanceController\MaintenanceController`
+*  Added status code `HTTP_TEMPORARY_REDIRECT` to redirect result in method `maintenanceResolver` in `Shopware\Storefront\Framework\Routing\StorefrontSubscriber`

--- a/src/Storefront/Controller/MaintenanceController.php
+++ b/src/Storefront/Controller/MaintenanceController.php
@@ -8,6 +8,7 @@ use Shopware\Core\Framework\Routing\Exception\MissingRequestParameterException;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Core\System\SystemConfig\SystemConfigService;
 use Shopware\Storefront\Framework\Cache\Annotation\HttpCache;
+use Shopware\Storefront\Framework\Routing\MaintenanceModeResolver;
 use Shopware\Storefront\Page\Maintenance\MaintenancePageLoader;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -28,12 +29,19 @@ class MaintenanceController extends StorefrontController
      */
     private $maintenancePageLoader;
 
+    /**
+     * @var MaintenanceModeResolver
+     */
+    private $maintenanceModeResolver;
+
     public function __construct(
         SystemConfigService $systemConfigService,
-        MaintenancePageLoader $maintenancePageLoader
+        MaintenancePageLoader $maintenancePageLoader,
+        MaintenanceModeResolver $maintenanceModeResolver
     ) {
         $this->systemConfigService = $systemConfigService;
         $this->maintenancePageLoader = $maintenancePageLoader;
+        $this->maintenanceModeResolver = $maintenanceModeResolver;
     }
 
     /**
@@ -44,7 +52,7 @@ class MaintenanceController extends StorefrontController
     {
         $salesChannel = $context->getSalesChannel();
 
-        if (!$salesChannel->isMaintenance()) {
+        if ($this->maintenanceModeResolver->shouldRedirectToShop($request)) {
             return $this->redirectToRoute('frontend.home.page');
         }
 
@@ -52,9 +60,14 @@ class MaintenanceController extends StorefrontController
         $maintenanceLayoutId = $this->systemConfigService->getString('core.basicInformation.maintenancePage', $salesChannelId);
 
         if ($maintenanceLayoutId === '') {
-            return $this->renderStorefront(
+            $response = $this->renderStorefront(
                 '@Storefront/storefront/page/error/error-maintenance.html.twig'
             );
+
+            $response->setStatusCode(Response::HTTP_SERVICE_UNAVAILABLE, 'Service Temporarily Unavailable');
+            $response->headers->set('Retry-After', '3600');
+
+            return $response;
         }
 
         $maintenancePage = $this->maintenancePageLoader->load($maintenanceLayoutId, $request, $context);
@@ -64,7 +77,8 @@ class MaintenanceController extends StorefrontController
             ['page' => $maintenancePage]
         );
 
-        $response->setStatusCode(Response::HTTP_OK);
+        $response->setStatusCode(Response::HTTP_SERVICE_UNAVAILABLE, 'Service Temporarily Unavailable');
+        $response->headers->set('Retry-After', '3600');
 
         return $response;
     }

--- a/src/Storefront/DependencyInjection/controller.xml
+++ b/src/Storefront/DependencyInjection/controller.xml
@@ -122,6 +122,7 @@
         <service id="Shopware\Storefront\Controller\MaintenanceController" public="true">
             <argument type="service" id="Shopware\Core\System\SystemConfig\SystemConfigService"/>
             <argument type="service" id="Shopware\Storefront\Page\Maintenance\MaintenancePageLoader"/>
+            <argument type="service" id="Shopware\Storefront\Framework\Routing\MaintenanceModeResolver"/>
             <call method="setContainer">
                 <argument type="service" id="service_container"/>
             </call>

--- a/src/Storefront/Framework/Routing/MaintenanceModeResolver.php
+++ b/src/Storefront/Framework/Routing/MaintenanceModeResolver.php
@@ -34,6 +34,14 @@ class MaintenanceModeResolver
             && !$this->isClientAllowed($request);
     }
 
+    public function shouldRedirectToShop(Request $request): bool
+    {
+        return !$this->isXmlHttpRequest($request)
+            && !$this->isErrorControllerRequest($request)
+            && (!$this->isMaintenanceModeActive($this->requestStack->getMasterRequest())
+                || $this->isClientAllowed($request));
+    }
+
     private function isSalesChannelRequest(?Request $master): bool
     {
         if (!$master) {

--- a/src/Storefront/Framework/Routing/StorefrontSubscriber.php
+++ b/src/Storefront/Framework/Routing/StorefrontSubscriber.php
@@ -241,7 +241,10 @@ class StorefrontSubscriber implements EventSubscriberInterface
     {
         if ($this->maintenanceModeResolver->shouldRedirect($event->getRequest())) {
             $event->setResponse(
-                new RedirectResponse($this->router->generate('frontend.maintenance.page'))
+                new RedirectResponse(
+                    $this->router->generate('frontend.maintenance.page'),
+                    RedirectResponse::HTTP_TEMPORARY_REDIRECT
+                )
             );
         }
     }

--- a/src/Storefront/Resources/views/storefront/page/error/error-maintenance.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/error/error-maintenance.html.twig
@@ -127,6 +127,14 @@
                     }
                 </script>
             {% endblock %}
+
+            {% block error_maintenance_script_reload %}
+                <script>
+                    setTimeout(function () {
+                        location.reload(true);
+                    }, 30000);
+                </script>
+            {% endblock %}
         {% endblock %}
     </body>
 {% endblock %}


### PR DESCRIPTION
### 1. What does this change do, exactly?
- Added auto reload to `error-maintenance.html.twig` with new block `error_maintenance_script_reload`
-  Added new function `shouldRedirectToShop` to `MaintenanceModeResolver`
   - Detail: this is necessary, cause the current implementation doesn't respect whitelistUrl
-  Added service `MaintenanceModeResolver` to `MaintenanceController`
   - Detail: we need the new function of `MaintenanceModeResolver`
-  Added status code with `HTTP_SERVICE_UNAVAILABLE` to `MaintenanceController`
   - Detail: This is the correct code for maintenance
-  Added header for `Retry-After` to `MaintenanceController`
   - Detail: This is the needed for search engines
-  Added status code with `HTTP_TEMPORARY_REDIRECT` to the RedirectResponse to `maintenance.page`
   - Detail: This is the needed for search engines

### 2. Describe each step to reproduce the issue or behaviour.


### 3. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/master/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
