### PR TITLE
NEXT-12667 - Add salutation to contact form data (fixes shopwareBoost…

### DIFF
--- a/changelog/_unreleased/2021-01-14-add-salutation-to-contact-form-data-in-contact-form-mails.md
+++ b/changelog/_unreleased/2021-01-14-add-salutation-to-contact-form-data-in-contact-form-mails.md
@@ -1,0 +1,9 @@
+---
+title: Add salutation to contact form data in contact form mails
+issue: NEXT-12667
+author: Timo Helmke
+author_email: t.helmke@kellerkinder.de 
+author_github: @t2oh4e
+---
+# Core
+*  Added salutation entity to contact form data to be used on customized mail templates

--- a/src/Core/Content/ContactForm/SalesChannel/ContactFormRoute.php
+++ b/src/Core/Content/ContactForm/SalesChannel/ContactFormRoute.php
@@ -50,18 +50,25 @@ class ContactFormRoute extends AbstractContactFormRoute
      */
     private $cmsSlotRepository;
 
+    /**
+     * @var EntityRepositoryInterface
+     */
+    private $salutationRepository;
+
     public function __construct(
         DataValidationFactoryInterface $contactFormValidationFactory,
         DataValidator $validator,
         EventDispatcherInterface $eventDispatcher,
         SystemConfigService $systemConfigService,
-        EntityRepositoryInterface $cmsSlotRepository
+        EntityRepositoryInterface $cmsSlotRepository,
+        EntityRepositoryInterface $salutationRepository
     ) {
         $this->contactFormValidationFactory = $contactFormValidationFactory;
         $this->validator = $validator;
         $this->eventDispatcher = $eventDispatcher;
         $this->systemConfigService = $systemConfigService;
         $this->cmsSlotRepository = $cmsSlotRepository;
+        $this->salutationRepository = $salutationRepository;
     }
 
     public function getDecorated(): AbstractContactFormRoute
@@ -116,6 +123,13 @@ class ContactFormRoute extends AbstractContactFormRoute
         }
 
         $this->validateContactForm($data, $context);
+
+        $salutationCriteria = new Criteria([$data->get('salutationId')]);
+        $salutationSearchResult = $this->salutationRepository->search($salutationCriteria, $context->getContext());
+
+        if ($salutationSearchResult->count() !== 0) {
+            $data->set('salutation', $salutationSearchResult->first());
+        }
 
         foreach ($receivers as $mail) {
             $event = new ContactFormEvent(

--- a/src/Core/Content/DependencyInjection/contact_form.xml
+++ b/src/Core/Content/DependencyInjection/contact_form.xml
@@ -15,6 +15,7 @@
             <argument type="service" id="event_dispatcher"/>
             <argument type="service" id="Shopware\Core\System\SystemConfig\SystemConfigService"/>
             <argument type="service" id="cms_slot.repository" />
+            <argument type="service" id="salutation.repository" />
         </service>
     </services>
 </container>


### PR DESCRIPTION
…day/platform#185)

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/contribution/contribution-guideline?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
To be able to acually use the selected salutation of the user

### 2. What does this change do, exactly?
Read the salutation by id when creating the mail event and add it to the databag

### 3. Describe each step to reproduce the issue or behaviour.
Create a contact form, try to access the salutation in the mail template. It's not available. After this fix you'll be able to use the data of the actual entity e.g. `{{ contactFormData.salutation.displayName }}`

### 4. Please link to the relevant issues (if any).
https://github.com/shopwareBoostDay/platform/issues/185

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/master/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.

Video showing the new behaviour: https://vimeo.com/500379214/71d3e3c7c9