### PR TITLE
NEXT-13262 - Add Hide On Product Detail option for properties

### DIFF
--- a/changelog/_unreleased/2021-01-14-add-hide-on-product-detail-option-for-properties.md
+++ b/changelog/_unreleased/2021-01-14-add-hide-on-product-detail-option-for-properties.md
@@ -1,0 +1,9 @@
+---
+title: Add Hide On Product Detail option for properties
+issue: NEXT-13262
+author: Rune Laenen
+author_email: rune@laenen.me 
+author_github: runelaenen
+---
+# Core
+* Add `visibleOnProductDetailPage` to `PropertGroup` entity to hide properties on the product detail page.

--- a/src/Administration/Resources/app/administration/src/module/sw-property/component/sw-property-detail-base/sw-property-detail-base.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-property/component/sw-property-detail-base/sw-property-detail-base.html.twig
@@ -21,14 +21,28 @@
                 :disabled="!allowEdit"/>
         {% endblock %}
 
-        {% block sw_property_detail_base_filterable %}
-            <sw-switch-field
-                name="propertyGroupFilterable"
-                class="sw-property-detail__filterable"
-                :label="$tc('sw-property.detail.labelFilterable')"
-                :disabled="!allowEdit"
-                v-model="propertyGroup.filterable">
-            </sw-switch-field>
+        {% block sw_property_detail_filter_visible_container %}
+            <sw-container columns="repeat(2, 1fr)" gap="0px 30px">
+                {% block sw_property_detail_base_filterable %}
+                    <sw-switch-field
+                        name="propertyGroupFilterable"
+                        class="sw-property-detail__filterable"
+                        :label="$tc('sw-property.detail.labelFilterable')"
+                        :disabled="!allowEdit"
+                        v-model="propertyGroup.filterable">
+                    </sw-switch-field>
+                {% endblock %}
+
+                {% block sw_property_detail_base_visible_on_detail %}
+                    <sw-switch-field
+                        name="propertyGroupvisibleOnProductDetailPage"
+                        class="sw-property-detail__visible-on-detail"
+                        :label="$tc('sw-property.detail.labelvisibleOnProductDetailPage')"
+                        :disabled="!allowEdit"
+                        v-model="propertyGroup.visibleOnProductDetailPage">
+                    </sw-switch-field>
+                {% endblock %}
+            </sw-container>
         {% endblock %}
 
         {% block sw_property_detail_sorting_display_container %}

--- a/src/Administration/Resources/app/administration/src/module/sw-property/page/sw-property-create/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-property/page/sw-property-create/index.js
@@ -22,6 +22,8 @@ Component.extend('sw-property-create', 'sw-property-detail', {
             this.propertyGroup.sortingType = 'alphanumeric';
             this.propertyGroup.displayType = 'text';
             this.propertyGroup.position = 1;
+            this.propertyGroup.filterable = true;
+            this.propertyGroup.visibleOnProductDetailPage = true;
             this.newId = this.propertyGroup.id;
 
             this.isLoading = false;

--- a/src/Administration/Resources/app/administration/src/module/sw-property/snippet/de-DE.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-property/snippet/de-DE.json
@@ -31,6 +31,7 @@
       "labelName": "Name",
       "placeholderName": "Namen eingeben ...",
       "labelFilterable": "Im Produktfilter von Produktlisten anzeigen",
+      "labelvisibleOnProductDetailPage": "Auf der Produktdetailseite anzeigen",
       "labelDisplayType": "Darstellung der Ausprägungsauswahl",
       "labelSortingType": "Sortierung",
       "labelOptionName": "Name",

--- a/src/Administration/Resources/app/administration/src/module/sw-property/snippet/en-GB.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-property/snippet/en-GB.json
@@ -31,6 +31,7 @@
       "labelName": "Name",
       "placeholderName": "Enter name...",
       "labelFilterable": "Display in product filters",
+      "labelvisibleOnProductDetailPage": "Display on product detail page",
       "labelDisplayType": "Value display type",
       "labelSortingType": "Sorting",
       "labelOptionName": "Name",

--- a/src/Core/Content/Product/Subscriber/ProductSubscriber.php
+++ b/src/Core/Content/Product/Subscriber/ProductSubscriber.php
@@ -50,7 +50,7 @@ class ProductSubscriber implements EventSubscriberInterface
         foreach ($properties as $option) {
             $origin = $option->getGroup();
 
-            if (!$origin) {
+            if (!$origin || !$origin->getVisibleOnProductDetailPage()) {
                 continue;
             }
             $group = clone $origin;

--- a/src/Core/Content/Property/PropertyGroupDefinition.php
+++ b/src/Core/Content/Property/PropertyGroupDefinition.php
@@ -38,6 +38,8 @@ class PropertyGroupDefinition extends EntityDefinition
 
     public const FILTERABLE = true;
 
+    public const VISIBLE_ON_PRODUCT_DETAIL_PAGE = true;
+
     public function getEntityName(): string
     {
         return self::ENTITY_NAME;
@@ -59,6 +61,7 @@ class PropertyGroupDefinition extends EntityDefinition
             'displayType' => self::DISPLAY_TYPE_TEXT,
             'sortingType' => self::SORTING_TYPE_ALPHANUMERIC,
             'filterable' => self::FILTERABLE,
+            'visibleOnProductDetailPage' => self::VISIBLE_ON_PRODUCT_DETAIL_PAGE,
         ];
     }
 
@@ -76,6 +79,7 @@ class PropertyGroupDefinition extends EntityDefinition
             (new StringField('display_type', 'displayType'))->setFlags(new Required()),
             (new StringField('sorting_type', 'sortingType'))->setFlags(new Required()),
             new BoolField('filterable', 'filterable'),
+            new BoolField('visible_on_product_detail_page', 'visibleOnProductDetailPage'),
             new TranslatedField('position'),
             new TranslatedField('customFields'),
             (new OneToManyAssociationField('options', PropertyGroupOptionDefinition::class, 'property_group_id', 'id'))->addFlags(new CascadeDelete(), new SearchRanking(SearchRanking::ASSOCIATION_SEARCH_RANKING)),

--- a/src/Core/Content/Property/PropertyGroupEntity.php
+++ b/src/Core/Content/Property/PropertyGroupEntity.php
@@ -42,6 +42,11 @@ class PropertyGroupEntity extends Entity
     protected $filterable;
 
     /**
+     * @var bool|null
+     */
+    protected $visibleOnProductDetailPage;
+
+    /**
      * @var PropertyGroupOptionCollection|null
      */
     protected $options;
@@ -74,6 +79,16 @@ class PropertyGroupEntity extends Entity
     public function setFilterable(bool $filterable): void
     {
         $this->filterable = $filterable;
+    }
+
+    public function getVisibleOnProductDetailPage(): bool
+    {
+        return $this->visibleOnProductDetailPage ?? false;
+    }
+
+    public function setVisibleOnProductDetailPage(bool $visibleOnProductDetailPage): void
+    {
+        $this->visibleOnProductDetailPage = $visibleOnProductDetailPage;
     }
 
     public function getOptions(): ?PropertyGroupOptionCollection

--- a/src/Core/Content/Test/Product/Subscriber/ProductLoadedSubscriberTest.php
+++ b/src/Core/Content/Test/Product/Subscriber/ProductLoadedSubscriberTest.php
@@ -34,7 +34,7 @@ class ProductLoadedSubscriberTest extends TestCase
     /**
      * @dataProvider propertyCases
      */
-    public function testSortProperties(array $product, $expected, array $languageChain, Criteria $criteria, bool $sort, array $language): void
+    public function testSortProperties(array $product, array $expected, array $unexpected, array $languageChain, Criteria $criteria, bool $sort, array $language): void
     {
         $this->getContainer()->get('product.repository')
             ->create([$product], Context::createDefaultContext());
@@ -71,6 +71,10 @@ class ProductLoadedSubscriberTest extends TestCase
                 static::assertEquals($option['id'], $optionElements[$optionId]->getId());
                 static::assertEquals($option['name'], $optionElements[$optionId]->getName());
             }
+        }
+
+        foreach ($unexpected as $unexpectedGroup) {
+            static::assertArrayNotHasKey($unexpectedGroup['id'], $sortedProperties);
         }
     }
 
@@ -118,6 +122,12 @@ class ProductLoadedSubscriberTest extends TestCase
                             'groupId' => $ids->get('taste'),
                             'group' => ['id' => $ids->get('taste'), 'name' => 'taste'],
                         ],
+                        [
+                            'id' => $ids->get('hiddenValue'),
+                            'name' => 'hiddenValue',
+                            'groupId' => $ids->get('hidden'),
+                            'group' => ['id' => $ids->get('hidden'), 'name' => 'hidden', 'visibleOnProductDetailPage' => false],
+                        ],
                     ],
                 ]),
                 [
@@ -132,6 +142,19 @@ class ProductLoadedSubscriberTest extends TestCase
                             $ids->get('sweet') => [
                                 'id' => $ids->get('sweet'),
                                 'name' => 'sweet',
+                            ],
+                        ],
+                    ],
+                ],
+                [
+                    [
+                        'id' => $ids->get('hidden'),
+                        'name' => 'hidden',
+                        'visibleOnProductDetailPage' => false,
+                        'options' => [
+                            $ids->get('hiddenValue') => [
+                                'id' => $ids->get('hiddenValue'),
+                                'name' => 'hiddenValue',
                             ],
                         ],
                     ],
@@ -206,6 +229,7 @@ class ProductLoadedSubscriberTest extends TestCase
                         ],
                     ],
                 ],
+                [],
                 [Defaults::LANGUAGE_SYSTEM],
                 (new Criteria()),
                 false,

--- a/src/Core/Migration/Migration1610616655AddVisibleOnDetailToPropertyGroup.php
+++ b/src/Core/Migration/Migration1610616655AddVisibleOnDetailToPropertyGroup.php
@@ -1,0 +1,27 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Migration;
+
+use Doctrine\DBAL\Connection;
+use Shopware\Core\Framework\Migration\MigrationStep;
+
+class Migration1610616655AddVisibleOnDetailToPropertyGroup extends MigrationStep
+{
+    public function getCreationTimestamp(): int
+    {
+        return 1610616655;
+    }
+
+    public function update(Connection $connection): void
+    {
+        $connection->executeUpdate('
+            ALTER TABLE `property_group`
+            ADD COLUMN `visible_on_product_detail_page` TINYINT(1) DEFAULT 1
+        ');
+    }
+
+    public function updateDestructive(Connection $connection): void
+    {
+        // implement update destructive
+    }
+}


### PR DESCRIPTION
### 1. Why is this change necessary?
Allows the admin to hide certain properties from product detail pages.

### 2. What does this change do, exactly?
Adds a checkbox to the Property Group administration view, adds a field to the PropertyGroup entity, filters the 'disabled' property groups out of the sortedProperties in the ProductLoader.

### 3. Describe each step to reproduce the issue or behaviour.
https://user-images.githubusercontent.com/3930922/104585386-358bba00-5664-11eb-9128-131edc9a330e.mov

### 4. Please link to the relevant issues (if any).
https://github.com/shopwareBoostDay/platform/issues/251

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/master/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
