### PR TITLE
NEXT-12093 - Fix custom fields empty state

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-settings-custom-field/page/sw-settings-custom-field-set-list/sw-settings-custom-field-set-list.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-custom-field/page/sw-settings-custom-field-set-list/sw-settings-custom-field-set-list.html.twig
@@ -161,6 +161,7 @@
                         {% endblock %}
                         {% block sw_settings_custom_fields_set_list_empty_message %}
                             <sw-empty-state v-if="!isLoading && items.length <= 0"
+                                            :absolute="false"
                                             :title="$tc('sw-settings-custom-field.set.list.messageEmpty')">
                             </sw-empty-state>
                         {% endblock %}


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/contribution/contribution-guideline?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
Currently, the Custom Fields have no Empty state. This should be added accordingly to the other empty states

### 2. What does this change do, exactly?
Set the `absolute` property on the empty state.

### 3. Describe each step to reproduce the issue or behaviour.
Go to Settings > Custom Fields. Remove all custom fields. You will not see an empty state.

### 4. Please link to the relevant issues (if any).
https://github.com/shopwareBoostDay/platform/issues/238

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/master/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
