### PR TITLE
NEXT-12360 - Swap h3 tag in filter panel offcanvas

### DIFF
--- a/src/Storefront/Resources/app/storefront/src/scss/component/_filter-panel.scss
+++ b/src/Storefront/Resources/app/storefront/src/scss/component/_filter-panel.scss
@@ -210,7 +210,6 @@ This file contains the generic styling for all filter items.
     .filter-panel-offcanvas-only {
         margin-bottom: 0;
         font-size: calc(1.275rem + 0.3vw);
-        margin-bottom: 0;
         line-height: 1.2;
         font-weight: 700;
     }

--- a/src/Storefront/Resources/app/storefront/src/scss/component/_filter-panel.scss
+++ b/src/Storefront/Resources/app/storefront/src/scss/component/_filter-panel.scss
@@ -207,8 +207,12 @@ This file contains the generic styling for all filter items.
     padding: 25px;
     display: none;
 
-    h3 {
+    .filter-panel-offcanvas-only {
         margin-bottom: 0;
+        font-size: calc(1.275rem + .3vw);
+        margin-bottom: 0;
+        line-height: 1.2;
+        font-weight: 700;
     }
 }
 

--- a/src/Storefront/Resources/app/storefront/src/scss/component/_filter-panel.scss
+++ b/src/Storefront/Resources/app/storefront/src/scss/component/_filter-panel.scss
@@ -209,7 +209,7 @@ This file contains the generic styling for all filter items.
 
     .filter-panel-offcanvas-only {
         margin-bottom: 0;
-        font-size: calc(1.275rem + .3vw);
+        font-size: calc(1.275rem + 0.3vw);
         margin-bottom: 0;
         line-height: 1.2;
         font-weight: 700;

--- a/src/Storefront/Resources/views/storefront/component/listing/filter-panel.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/listing/filter-panel.html.twig
@@ -1,7 +1,7 @@
 {% block component_filter_panel %}
     {% block component_filter_panel_header %}
         <div class="filter-panel-offcanvas-header">
-            <h3 class="filter-panel-offcanvas-only">{{ "listing.filterTitleText"|trans }}</h3>
+            <span class="filter-panel-offcanvas-only">{{ "listing.filterTitleText"|trans }}</span>
 
             <div class="filter-panel-offcanvas-only filter-panel-offcanvas-close js-offcanvas-close">
                 {% sw_icon 'x' style { 'size': 'md' } %}


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/contribution/contribution-guideline?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
From SEO point of view, h-tags should not be used in the theme. 

### 2. What does this change do, exactly?
Replaced h3 with span tag

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
https://github.com/shopwareBoostDay/platform/issues/186

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/master/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
