### PR TITLE
NEXT-7997 - Add dropdown display for variant properties fixes shopwar…

### DIFF
--- a/changelog/_unreleased/2021-01-14-add-select-to-property-display-type.md
+++ b/changelog/_unreleased/2021-01-14-add-select-to-property-display-type.md
@@ -1,0 +1,14 @@
+---
+title: Add select display type to properties
+issue: NEXT-7997
+author: Sebastian Lember, Timo Boomgaarden
+author_email: lember@hochwarth-it.de, boomgaarden@hochwarth-it.de 
+author_github: @sebi007, @timoboomgaarden
+---
+# Administration
+*  Added select value to `displayTypes` in `sw-property-detail-base` 
+___
+# Storefront
+*  Added select-element to `storefront/page/product-detail/configurator.html.twig`
+*  Added selector for select-elements in `variant-switch.plugin.js`
+*  Changed `_getFormValue()` to also iterate over select-elements for variant switching in `variant-switch.plugin.js`

--- a/src/Administration/Resources/app/administration/src/module/sw-property/component/sw-property-detail-base/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-property/component/sw-property-detail-base/index.js
@@ -40,6 +40,7 @@ Component.register('sw-property-detail-base', {
             displayTypes: [
                 { value: 'media', label: this.$tc('sw-property.detail.mediaDisplayType') },
                 { value: 'text', label: this.$tc('sw-property.detail.textDisplayType') },
+                { value: 'select', label: this.$tc('sw-property.detail.selectDisplayType') },
                 { value: 'color', label: this.$tc('sw-property.detail.colorDisplayType') }
             ]
         };

--- a/src/Administration/Resources/app/administration/src/module/sw-property/snippet/de-DE.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-property/snippet/de-DE.json
@@ -23,6 +23,7 @@
     "detail": {
       "mediaDisplayType": "Bild",
       "textDisplayType": "Text",
+      "selectDisplayType": "Dropdown",
       "colorDisplayType": "Farbe",
       "numericSortingType": "Numerisch",
       "alphanumericSortingType": "Alphanumerisch",

--- a/src/Administration/Resources/app/administration/src/module/sw-property/snippet/en-GB.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-property/snippet/en-GB.json
@@ -23,6 +23,7 @@
     "detail": {
       "mediaDisplayType": "Image",
       "textDisplayType": "Text",
+      "selectDisplayType": "Dropdown",
       "colorDisplayType": "Colour",
       "numericSortingType": "Numeric",
       "alphanumericSortingType": "Alphanumeric",

--- a/src/Storefront/Resources/app/storefront/src/plugin/variant-switch/variant-switch.plugin.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/variant-switch/variant-switch.plugin.js
@@ -14,12 +14,14 @@ export default class VariantSwitchPlugin extends Plugin {
     static options = {
         url: '',
         elementId: '',
-        radioFieldSelector: '.product-detail-configurator-option-input'
+        radioFieldSelector: '.product-detail-configurator-option-input',
+        selectFieldSelector: '.product-detail-configurator-select-input'
     };
 
     init() {
         this._httpClient = new HttpClient();
-        this._radioFields = DomAccess.querySelectorAll(this.el, this.options.radioFieldSelector);
+        this._radioFields = DomAccess.querySelectorAll(this.el, this.options.radioFieldSelector, false);
+        this._selectFields = DomAccess.querySelectorAll(this.el, this.options.selectFieldSelector, false);
         this._elementId = this.options.elementId;
 
         this._ensureFormElement();
@@ -45,13 +47,15 @@ export default class VariantSwitchPlugin extends Plugin {
      * @private
      */
     _preserveCurrentValues() {
-        Iterator.iterate(this._radioFields, field => {
-            if (VariantSwitchPlugin._isFieldSerializable(field)) {
-                if (field.dataset) {
-                    field.dataset.variantSwitchValue = field.value;
+        if(this._radioFields) {
+            Iterator.iterate(this._radioFields, field => {
+                if (VariantSwitchPlugin._isFieldSerializable(field)) {
+                    if (field.dataset) {
+                        field.dataset.variantSwitchValue = field.value;
+                    }
                 }
-            }
-        });
+            });
+        }
     }
 
     /**
@@ -114,13 +118,24 @@ export default class VariantSwitchPlugin extends Plugin {
      */
     _getFormValue() {
         const serialized = {};
-        Iterator.iterate(this._radioFields, field => {
-            if (VariantSwitchPlugin._isFieldSerializable(field)) {
-                if (field.checked) {
-                    serialized[field.name] = field.value;
+        if(this._radioFields) {
+            Iterator.iterate(this._radioFields, field => {
+                if (VariantSwitchPlugin._isFieldSerializable(field)) {
+                    if (field.checked) {
+                        serialized[field.name] = field.value;
+                    }
                 }
-            }
-        });
+            });
+        }
+
+        if(this._selectFields) {
+            Iterator.iterate(this._selectFields, field => {
+                if (VariantSwitchPlugin._isFieldSerializable(field)) {
+                    const selectedOption = [...field.options].find(option => option.selected);
+                    serialized[field.name] = selectedOption.value;
+                }
+            });
+        }
 
         return serialized;
     }

--- a/src/Storefront/Resources/views/storefront/page/product-detail/configurator.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/product-detail/configurator.html.twig
@@ -15,90 +15,94 @@
                     {% for group in page.configuratorSettings %}
                         {% block page_product_detail_configurator_group %}
                             <div class="product-detail-configurator-group">
-                                {% block page_product_detail_configurator_group_title %}
-                                    <div class="product-detail-configurator-group-title">
-                                        {% block page_product_detail_configurator_group_title_text %}
-                                            {{ group.translated.name }}
-                                        {% endblock %}
-                                    </div>
-                                {% endblock %}
-
-                                {% block page_product_detail_configurator_options %}
-                                    <div class="product-detail-configurator-options">
-                                        {% for option in group.options %}
-
-                                            {% set optionIdentifier = [group.id, option.id]|join('-') %}
-                                            {% set isActive = false %}
-                                            {% set isCombinableCls = 'is-combinable' %}
-
-                                            {% if option.id in page.product.optionIds %}
-                                                {% set isActive = true %}
-                                            {% endif %}
-
-                                            {% if not option.combinable %}
-                                                {% set isCombinableCls = false %}
-                                            {% endif %}
-
-                                            {% if option.configuratorSetting.media %}
-                                                {% set displayType = 'media' %}
-                                                {% set media = option.configuratorSetting.media %}
-                                            {% else %}
-                                                {% set displayType = group.displayType %}
-                                                {% if option.media %}
-                                                    {% set media = option.media %}
-                                                {% else %}
-                                                    {% set media = false %}
-                                                {% endif %}
-                                            {% endif %}
-
-                                            {% block page_product_detail_configurator_option %}
-                                                <div class="product-detail-configurator-option">
-                                                    {% block page_product_detail_configurator_option_radio %}
-                                                        <input type="radio"
-                                                               name="{{ group.id }}"
-                                                               value="{{ option.id }}"
-                                                               class="product-detail-configurator-option-input{% if isCombinableCls %} {{ isCombinableCls }}{% endif %}"
-                                                               title="{{ optionIdentifier }}"
-                                                               id="{{ optionIdentifier }}"
-                                                               {% if isActive %}checked="checked"{% endif %}>
-
-                                                        {% block page_product_detail_configurator_option_radio_label %}
-                                                            <label class="product-detail-configurator-option-label{% if isCombinableCls %} {{ isCombinableCls }}{% endif %} is-display-{{ displayType }}"
-                                                                   {% if displayType == 'color' and option.colorHexCode %}
-                                                                   style="background-color: {{ option.colorHexCode }}"
-                                                                   {% endif %}
-                                                                   title="{{ option.translated.name }}"
-                                                                   for="{{ optionIdentifier }}">
-
-                                                                {% if displayType == 'media' and media %}
-                                                                    {% block page_product_detail_configurator_option_radio_label_media %}
-                                                                        {% sw_thumbnails 'configurator-option-img-thumbnails' with {
-                                                                            media: media,
-                                                                            sizes: {
-                                                                                'default': '52px'
-                                                                            },
-                                                                            attributes: {
-                                                                                'class': 'product-detail-configurator-option-image',
-                                                                                'alt': option.translated.name,
-                                                                                'title': option.translated.name
-                                                                            }
-                                                                        } %}
-                                                                    {% endblock %}
-                                                                {% elseif displayType == 'text' or
-                                                                          (displayType == 'media' and not media) or
-                                                                          (displayType == 'color' and not option.colorHexCode) %}
-                                                                    {% block page_product_detail_configurator_option_radio_label_text %}
-                                                                        {{ option.translated.name }}
-                                                                    {% endblock %}
-                                                                {% endif %}
-                                                            </label>
-                                                        {% endblock %}
-                                                    {% endblock %}
-                                                </div>
+                                {% if group.displayType == 'select' %}
+                                    {% sw_include '@Storefront/storefront/page/product-detail/configurator/select.html.twig' %}
+                                {% else %}
+                                    {% block page_product_detail_configurator_group_title %}
+                                        <div class="product-detail-configurator-group-title">
+                                            {% block page_product_detail_configurator_group_title_text %}
+                                                {{ group.translated.name }}
                                             {% endblock %}
-                                        {% endfor %}
-                                    </div>
-                                {% endblock %}
+                                        </div>
+                                    {% endblock %}
+
+                                    {% block page_product_detail_configurator_options %}
+                                        <div class="product-detail-configurator-options">
+                                            {% for option in group.options %}
+
+                                                {% set optionIdentifier = [group.id, option.id]|join('-') %}
+                                                {% set isActive = false %}
+                                                {% set isCombinableCls = 'is-combinable' %}
+
+                                                {% if option.id in page.product.optionIds %}
+                                                    {% set isActive = true %}
+                                                {% endif %}
+
+                                                {% if not option.combinable %}
+                                                    {% set isCombinableCls = false %}
+                                                {% endif %}
+
+                                                {% if option.configuratorSetting.media %}
+                                                    {% set displayType = 'media' %}
+                                                    {% set media = option.configuratorSetting.media %}
+                                                {% else %}
+                                                    {% set displayType = group.displayType %}
+                                                    {% if option.media %}
+                                                        {% set media = option.media %}
+                                                    {% else %}
+                                                        {% set media = false %}
+                                                    {% endif %}
+                                                {% endif %}
+
+                                                {% block page_product_detail_configurator_option %}
+                                                    <div class="product-detail-configurator-option">
+                                                        {% block page_product_detail_configurator_option_radio %}
+                                                            <input type="radio"
+                                                                   name="{{ group.id }}"
+                                                                   value="{{ option.id }}"
+                                                                   class="product-detail-configurator-option-input{% if isCombinableCls %} {{ isCombinableCls }}{% endif %}"
+                                                                   title="{{ optionIdentifier }}"
+                                                                   id="{{ optionIdentifier }}"
+                                                                   {% if isActive %}checked="checked"{% endif %}>
+
+                                                            {% block page_product_detail_configurator_option_radio_label %}
+                                                                <label class="product-detail-configurator-option-label{% if isCombinableCls %} {{ isCombinableCls }}{% endif %} is-display-{{ displayType }}"
+                                                                       {% if displayType == 'color' and option.colorHexCode %}
+                                                                       style="background-color: {{ option.colorHexCode }}"
+                                                                       {% endif %}
+                                                                       title="{{ option.translated.name }}"
+                                                                       for="{{ optionIdentifier }}">
+
+                                                                    {% if displayType == 'media' and media %}
+                                                                        {% block page_product_detail_configurator_option_radio_label_media %}
+                                                                            {% sw_thumbnails 'configurator-option-img-thumbnails' with {
+                                                                                media: media,
+                                                                                sizes: {
+                                                                                    'default': '52px'
+                                                                                },
+                                                                                attributes: {
+                                                                                    'class': 'product-detail-configurator-option-image',
+                                                                                    'alt': option.translated.name,
+                                                                                    'title': option.translated.name
+                                                                                }
+                                                                            } %}
+                                                                        {% endblock %}
+                                                                    {% elseif displayType == 'text' or
+                                                                              (displayType == 'media' and not media) or
+                                                                              (displayType == 'color' and not option.colorHexCode) %}
+                                                                        {% block page_product_detail_configurator_option_radio_label_text %}
+                                                                            {{ option.translated.name }}
+                                                                        {% endblock %}
+                                                                    {% endif %}
+                                                                </label>
+                                                            {% endblock %}
+                                                        {% endblock %}
+                                                    </div>
+                                                {% endblock %}
+                                            {% endfor %}
+                                        </div>
+                                    {% endblock %}
+                                {% endif %}
                             </div>
                         {% endblock %}
                     {% endfor %}

--- a/src/Storefront/Resources/views/storefront/page/product-detail/configurator/select.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/product-detail/configurator/select.html.twig
@@ -1,0 +1,27 @@
+{% block page_product_detail_configurator_group_select %}
+    {% block page_product_detail_configurator_group_select_title %}
+        <label class="product-detail-configurator-group-title" for="{{ group.id }}">
+            {% block page_product_detail_configurator_group_title_text %}
+                {{ group.translated.name }}
+            {% endblock %}
+        </label>
+        {% block page_product_detail_configurator_select %}
+            <select name="{{ group.id }}" id="{{ group.id }}" class="custom-select product-detail-configurator-select-input">
+                {% for option in group.options %}
+
+                    {% set selected = false %}
+
+                    {% if option.id in page.product.optionIds %}
+                        {% set selected = true %}
+                    {% endif %}
+
+                    {% block page_product_detail_configurator_select_option %}
+                        <option value="{{ option.id }}"{% if selected %} selected="selected"{% endif %}>
+                            {{ option.translated.name }}
+                        </option>
+                    {% endblock %}
+                {% endfor %}
+            </select>
+        {% endblock %}
+    {% endblock %}
+{% endblock %}


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/contribution/contribution-guideline?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
Currently the only options to display the variant switches are as radio buttons. It's not possible to have the variant switch shown as dropdown.

### 2. What does this change do, exactly?
This change adds a new option to the property display type. Also the display in the frontend was changed, that properties with display type 'select' are shown as select-elements instead of radio buttons.

### 3. Describe each step to reproduce the issue or behaviour.
* Add variants to a product
* Go to frontend
* All properties are displayed as radio buttons

### 4. Please link to the relevant issues (if any).
#229

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/master/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
