### PR TITLE
NEXT-11384 - Add cancel button on template settings

### DIFF
--- a/changelog/_unreleased/2021-01-14-add-cancel-button-to-email-template-settings.md
+++ b/changelog/_unreleased/2021-01-14-add-cancel-button-to-email-template-settings.md
@@ -1,0 +1,9 @@
+---
+title: Add cancel buttons to sw-mail-template
+issue: NEXT-11384
+author: Stefanos Stvakis
+author_email: stvakis@gmail.com
+author_github: StVak
+---
+# Administration
+* Add missing cancel buttons to `sw-mail-template` module

--- a/src/Administration/Resources/app/administration/src/module/sw-mail-template/page/sw-mail-header-footer-detail/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-mail-template/page/sw-mail-header-footer-detail/index.js
@@ -21,7 +21,8 @@ Component.register('sw-mail-header-footer-detail', {
                 return this.allowSave;
             },
             method: 'onSave'
-        }
+        },
+        ESCAPE: 'onCancel'
     },
 
     data() {
@@ -156,6 +157,10 @@ Component.register('sw-mail-header-footer-detail', {
 
         saveFinish() {
             this.isSaveSuccessful = false;
+        },
+
+        onCancel() {
+            this.$router.push({ name: 'sw.mail.template.index' });
         },
 
         onSave() {

--- a/src/Administration/Resources/app/administration/src/module/sw-mail-template/page/sw-mail-header-footer-detail/sw-mail-header-footer-detail.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-mail-template/page/sw-mail-header-footer-detail/sw-mail-header-footer-detail.html.twig
@@ -9,6 +9,18 @@
 
         {% block sw_mail_header_footer_detail_actions %}
             <template #smart-bar-actions>
+                {% block sw_mail_header_footer_detail_actions_abort %}
+                    <sw-button
+                        v-tooltip.bottom="{
+                        message: 'ESC',
+                        appearance: 'light'
+                        }"
+                        :disabled="isLoading"
+                        @click="onCancel">
+                        {{ $tc('sw-mail-header-footer.detail.buttonCancel') }}
+                    </sw-button>
+                {% endblock %}
+                
                 {% block sw_mail_header_footer_detail_actions_save %}
                 <sw-button-process
                     v-tooltip.bottom="tooltipSave"

--- a/src/Administration/Resources/app/administration/src/module/sw-mail-template/page/sw-mail-template-detail/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-mail-template/page/sw-mail-template-detail/index.js
@@ -22,7 +22,8 @@ Component.register('sw-mail-template-detail', {
                 return this.allowSave;
             },
             method: 'onSave'
-        }
+        },
+        ESCAPE: 'onCancel'
     },
 
     data() {
@@ -231,6 +232,10 @@ Component.register('sw-mail-template-detail', {
 
         saveFinish() {
             this.isSaveSuccessful = false;
+        },
+
+        onCancel() {
+            this.$router.push({ name: 'sw.mail.template.index' });
         },
 
         onSave() {

--- a/src/Administration/Resources/app/administration/src/module/sw-mail-template/page/sw-mail-template-detail/sw-mail-template-detail.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-mail-template/page/sw-mail-template-detail/sw-mail-template-detail.html.twig
@@ -10,6 +10,18 @@
 
         {% block sw_mail_template_detail_actions %}
             <template #smart-bar-actions>
+                {% block sw_mail_template_detail_actions_abort %}
+                    <sw-button
+                        v-tooltip.bottom="{
+                        message: 'ESC',
+                        appearance: 'light'
+                        }"
+                        :disabled="isLoading"
+                        @click="onCancel">
+                        {{ $tc('sw-mail-template.detail.buttonCancel') }}
+                    </sw-button>
+                {% endblock %}
+
                 {% block sw_mail_template_detail_actions_save %}
                     <sw-button-process
                         v-tooltip.bottom="tooltipSave"


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/contribution/contribution-guideline?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
Add cancel buttons to email template settings

### 2. What does this change do, exactly?
Add cancel buttons to email template settings

### 3. Describe each step to reproduce the issue or behaviour.
Go to Settings ->  Email templates, add new or edit a template, Cancel button is missing

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/master/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
