### PR TITLE
NEXT-9698 - Removal of cover in adminstration if last media is deleted

### DIFF
--- a/changelog/_unreleased/2021-01-14-removal-of-in-adminstration-if-last-media-is-deleted.md
+++ b/changelog/_unreleased/2021-01-14-removal-of-in-adminstration-if-last-media-is-deleted.md
@@ -1,0 +1,9 @@
+---
+title: Removal of cover in adminstration if last media is deleted
+issue: NEXT-9698
+author: Max
+author_email: max@swk-web.com
+author_github: @aragon999
+---
+# Administration
+- Changed that if the last media of a product, that the cover is also properly removed

--- a/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-media-form/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-media-form/index.js
@@ -229,11 +229,11 @@ Component.register('sw-product-media-form', {
                 this.product.coverId = null;
             }
 
+            this.product.media.remove(productMedia.id);
+
             if (this.product.coverId === null && this.product.media.length > 0) {
                 this.product.coverId = this.product.media.first().id;
             }
-
-            this.product.media.remove(productMedia.id);
         },
 
         markMediaAsCover(productMedia) {

--- a/src/Administration/Resources/app/administration/test/module/sw-product/component/sw-product-media-form.spec.js
+++ b/src/Administration/Resources/app/administration/test/module/sw-product/component/sw-product-media-form.spec.js
@@ -117,4 +117,14 @@ describe('module/sw-product/component/sw-product-media-form', () => {
 
         expect(coverCount).toBe(1);
     });
+
+    it('should remove the cover properly if all medias removed', async () => {
+        const wrapper = createWrapper();
+
+        wrapper.vm.mediaItems.forEach(mediaItem => {
+            wrapper.vm.removeFile(mediaItem);
+        });
+
+        expect(wrapper.vm.product.cover).toBe(null);
+    });
 });


### PR DESCRIPTION
### 1. Why is this change necessary?
If the last media of a product was removed the cover was not automatically removed.

### 2. What does this change do, exactly?
The problem was, that after the removal of the cover it was set again, since the media was not removed before checking if there is a new cover. Therefore the order of the code is changed, which fixes the issue.

### 3. Describe each step to reproduce the issue or behaviour.
Delete all images of a product.

### 4. Please link to the relevant issues (if any).
https://github.com/shopwareBoostDay/platform/issues/208

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/master/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
