### PR TITLE
NEXT-7986 - Use img element for Hero Image CMS element

### DIFF
--- a/changelog/_unreleased/2021-01-14-use-img-element-for-hero-image-cms-element.md
+++ b/changelog/_unreleased/2021-01-14-use-img-element-for-hero-image-cms-element.md
@@ -1,0 +1,12 @@
+---
+title: Use img element for Hero Image CMS element
+issue: NEXT-7986
+author: Rune Laenen
+author_email: rune@laenen.me 
+author_github: runelaenen
+---
+# Storefront
+*  Changed use of inline `background-image` to usage of `sw_thumbnails` to have responsive image resolutions
+___
+# Upgrade Information
+Due to the way that `img`'s `object-fit` works, it is not possible to mimic the 'Auto' setting of the block background. This means that elements that currently have 'Auto' set as their background mode will look different.

--- a/src/Storefront/Resources/app/storefront/src/scss/component/_cms-block.scss
+++ b/src/Storefront/Resources/app/storefront/src/scss/component/_cms-block.scss
@@ -9,8 +9,32 @@ specific styling for elements dependent on their parent block
     overflow: hidden;
 
     &.bg-image {
+        position: relative;
         background-repeat: no-repeat;
         background-position: 50%;
+    }
+
+    .cms-block-background {
+        position: absolute;
+        top: 0;
+        right: 0;
+        bottom: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+
+        object-fit: none;
+        font-family: 'object-fit: none;';
+
+        &.media-mode--contain {
+            object-fit: contain;
+            font-family: 'object-fit: contain;';
+        }
+
+        &.media-mode--cover {
+            object-fit: cover;
+            font-family: 'object-fit: cover;';
+        }
     }
 
     .cms-block-container {

--- a/src/Storefront/Resources/views/storefront/section/cms-section-block-container.html.twig
+++ b/src/Storefront/Resources/views/storefront/section/cms-section-block-container.html.twig
@@ -10,11 +10,10 @@
     {% endif %}
 
     {% set blockBgColor = block.backgroundColor %}
-    {% set blockBgImg = block.backgroundMedia|sw_encode_media_url %}
 
     {% set blockClasses = [block.cssClass, 'pos-' ~ block.position, 'cms-block-' ~ block.type] %}
 
-    {% if blockBgImg %}
+    {% if block.backgroundMedia %}
         {% set blockClasses = ['bg-image']|merge(blockClasses) %}
     {% endif %}
 
@@ -31,7 +30,17 @@
     {% endif %}
 
     <div class="cms-block {{ blockClasses|join(' ') }}"
-         style="{% if blockBgColor %} background-color: {{ blockBgColor }};{% endif %}{% if blockBgImg %}background-image: url({{ blockBgImg }}); background-size: {{ block.backgroundMediaMode }};{% endif %}">
+         style="{% if blockBgColor %} background-color: {{ blockBgColor }};{% endif %}">
+        {% block section_content_block_background_image %}
+            {% if block.backgroundMedia %}
+                {% sw_thumbnails 'cms-block-background' with {
+                    media: block.backgroundMedia,
+                    attributes: {
+                        class: "cms-block-background media-mode--" ~ block.backgroundMediaMode
+                    }
+                    } %}
+            {% endif %}
+        {% endblock %}
 
         {% block section_content_block_container %}
             <div class="cms-block-container"


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/contribution/contribution-guideline?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
Shopping Experiences:
When choosing a "Hero image" element in a layout, the different generated thumbnail sizes aren't being used, but the original image in its original size. This means that the image is not adjusted, for example in mobile views.

### 2. What does this change do, exactly?
Change the usage of an inline background-image style to the sw_thumbnail twig function.

Due to the way that img's object-fit works, it is not possible to mimic the 'Auto' setting of the block background. This means that elements that currently have 'Auto' set as their background mode will look different.

### 3. Describe each step to reproduce the issue or behaviour.
![Screenshot 2021-01-14 at 15 52 14](https://user-images.githubusercontent.com/3930922/104606938-9628f000-5680-11eb-9db0-c0bef9535f9f.png)

### 4. Please link to the relevant issues (if any).
https://github.com/shopwareBoostDay/platform/issues/230

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/master/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
