### PR TITLE
NEXT-11401 - Add additional error message on `sw-product` save

### DIFF
--- a/changelog/_unreleased/2021-01-14-add-correct-error-message-on-saving-an-product-with-already-existing-product-no.md
+++ b/changelog/_unreleased/2021-01-14-add-correct-error-message-on-saving-an-product-with-already-existing-product-no.md
@@ -1,0 +1,9 @@
+---
+title: Add correct error message on saving an product with already existing product no.
+issue: NEXT-11401
+author: Jonas Dambacher
+author_email: j.dambacher@basecom.de
+author_github: jdambacher
+---
+# Administration
+* Added correct error message on saving an product with already existing product no.

--- a/src/Administration/Resources/app/administration/src/module/sw-product/page/sw-product-detail/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/page/sw-product-detail/index.js
@@ -498,6 +498,21 @@ Component.register('sw-product-detail', {
                     }
 
                     default: {
+                        const errorCode = Shopware.Utils.get(response, 'response.data.errors[0].code');
+
+                        if (errorCode === 'CONTENT__DUPLICATE_PRODUCT_NUMBER') {
+                            const titleSaveError = this.$tc('global.default.error');
+                            const messageSaveError = this.$t(
+                                'sw-product.notification.notificationSaveErrorProductNoAlreadyExists', { productNo: response.response.data.errors[0].meta.parameters.number }
+                            );
+
+                            this.createNotificationError({
+                                title: titleSaveError,
+                                message: messageSaveError
+                            });
+                            break;
+                        }
+
                         const titleSaveError = this.$tc('global.default.error');
                         const messageSaveError = this.$tc(
                             'global.notification.notificationSaveErrorMessageRequiredFieldsInvalid'

--- a/src/Administration/Resources/app/administration/src/module/sw-product/snippet/de-DE.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/snippet/de-DE.json
@@ -385,6 +385,9 @@
       "textChangeLayout": "Layout ändern",
       "textCreateNewLayout": "Neues Layout erstellen",
       "textEditInDesigner": "Im Designer bearbeiten"
+    },
+    "notification": {
+      "notificationSaveErrorProductNoAlreadyExists": "Die Produktnummer \"{productNo}\" ist bereits vergeben."
     }
   },
   "sw-privileges": {

--- a/src/Administration/Resources/app/administration/src/module/sw-product/snippet/en-GB.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/snippet/en-GB.json
@@ -384,6 +384,9 @@
       "textChangeLayout": "Change layout",
       "textCreateNewLayout": "Create new layout",
       "textEditInDesigner": "Edit in designer"
+    },
+    "notification": {
+      "notificationSaveErrorProductNoAlreadyExists": "Product No. \"{productNo}\" is already assigned."
     }
   },
   "sw-privileges": {


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/contribution/contribution-guideline?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
When you save/create a product and enter an already existing product no., the error message is not clear.

### 2. What does this change do, exactly?
It shows an error message that the product no. already exists.

### 3. Describe each step to reproduce the issue or behaviour.
-

### 4. Please link to the relevant issues (if any).
#241 

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/master/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
