### PR TITLE
NEXT-9611 - Close preview modal in cross selling, fixes shopwareBoost…

### DIFF
--- a/changelog/_unreleased/2021-01-14-close-preview-modal-in-cross-selling.md
+++ b/changelog/_unreleased/2021-01-14-close-preview-modal-in-cross-selling.md
@@ -1,0 +1,11 @@
+---
+title: Close preview modal in cross selling
+issue: NEXT-9611
+author: Sebastian Lember, Timo Boomgaarden
+author_email: lember@hochwarth-it.de, boomgaarden@hochwarth-it.de 
+author_github: @sebi007, @timoboomgaarden
+---
+
+# Administration
+*  Added `prepareToExit` to `sw-product-cross-selling-form`
+*  Added `beforeRouteLeave` to `sw-product-detail-cross-selling`

--- a/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-cross-selling-form/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-cross-selling-form/index.js
@@ -178,6 +178,12 @@ Component.register('sw-product-cross-selling-form', {
 
         onTypeChanged(value) {
             this.useManualAssignment = value === 'productList';
+        },
+
+        prepareToExit() {
+            if (this.showModalPreview) {
+                this.showModalPreview = false;
+            }
         }
     }
 });

--- a/src/Administration/Resources/app/administration/src/module/sw-product/view/sw-product-detail-cross-selling/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/view/sw-product-detail-cross-selling/index.js
@@ -18,6 +18,14 @@ Component.register('sw-product-detail-cross-selling', {
         }
     },
 
+    beforeRouteLeave(to, from, next) {
+        for (let i = 0; i < this.$refs.crossSellingForm.length; i += 1) {
+            this.$refs.crossSellingForm[i].prepareToExit();
+        }
+
+        this.$nextTick(() => next());
+    },
+
     data() {
         return {
             crossSelling: null

--- a/src/Administration/Resources/app/administration/src/module/sw-product/view/sw-product-detail-cross-selling/sw-product-detail-cross-selling.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/view/sw-product-detail-cross-selling/sw-product-detail-cross-selling.html.twig
@@ -6,6 +6,7 @@
                 <sw-product-cross-selling-form
                     v-for="item in product.crossSellings"
                     :key="item.id"
+                    ref="crossSellingForm"
                     :crossSelling="item"
                     :allowEdit="acl.can('product.editor')">
                 </sw-product-cross-selling-form>


### PR DESCRIPTION
…Day/platform#210

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/contribution/contribution-guideline?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
Preview modal was not closed after navigation to product in cross selling

### 2. What does this change do, exactly?
This change adds the beforeRouteLeave route guard to sw-product-detail-cross-selling which calls a function prepareToExit in sw-product-cross-selling-form

### 3. Describe each step to reproduce the issue or behaviour.
* Open a product
* Go to cross selling
* Assign a dynamic product group to the cross selling
* Click on 'Open preview'
* Click on a product

### 4. Please link to the relevant issues (if any).
#210 

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/master/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
