### PR TITLE
NEXT-13424 - Add events when Billing Address/ Shipping Address is set as default

### DIFF
--- a/changelog/_unreleased/2021-01-14-events-on-setting-default-billing-and-shipping-addresses.md
+++ b/changelog/_unreleased/2021-01-14-events-on-setting-default-billing-and-shipping-addresses.md
@@ -1,0 +1,9 @@
+---
+title:              Dispatch events when Billing Address/ Shipping Address is set as default
+issue:              NEXT-265
+author:             Shanthini Rajarathinam
+author_email:       sr@imc-web.de
+author_github:      sr-SW6-workshop
+---
+# Core
+*  Added Event dispatcher events when an address is set as default billing or shipping address by the customer

--- a/src/Core/Checkout/Customer/Event/CustomerSetDefaultBillingAddressEvent.php
+++ b/src/Core/Checkout/Customer/Event/CustomerSetDefaultBillingAddressEvent.php
@@ -1,0 +1,94 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Checkout\Customer\Event;
+
+use Shopware\Core\Checkout\Customer\CustomerDefinition;
+use Shopware\Core\Checkout\Customer\CustomerEntity;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Event\BusinessEventInterface;
+use Shopware\Core\Framework\Event\EventData\EntityType;
+use Shopware\Core\Framework\Event\EventData\EventDataCollection;
+use Shopware\Core\Framework\Event\EventData\ScalarValueType;
+use Shopware\Core\Framework\Event\SalesChannelAware;
+use Shopware\Core\Framework\Event\ShopwareSalesChannelEvent;
+use Shopware\Core\System\SalesChannel\SalesChannelContext;
+use Symfony\Contracts\EventDispatcher\Event;
+
+class CustomerSetDefaultBillingAddressEvent extends Event implements BusinessEventInterface, SalesChannelAware, ShopwareSalesChannelEvent
+{
+    public const EVENT_NAME = 'checkout.customer.default.billing.address.event';
+
+    /**
+     * @var CustomerEntity
+     */
+    private $customer;
+
+    /**
+     * @var SalesChannelContext
+     */
+    private $salesChannelContext;
+
+    /**
+     * @var string
+     */
+    private $contextToken;
+
+    /**
+     * @var string
+     */
+    private $addressId;
+
+    public function __construct(SalesChannelContext $salesChannelContext, CustomerEntity $customer, string $addressId)
+    {
+        $this->customer = $customer;
+        $this->salesChannelContext = $salesChannelContext;
+        $this->addressId = $addressId;
+    }
+
+    public function getName(): string
+    {
+        return self::EVENT_NAME;
+    }
+
+    public function getCustomer(): CustomerEntity
+    {
+        return $this->customer;
+    }
+
+    public function getSalesChannelContext(): SalesChannelContext
+    {
+        return $this->salesChannelContext;
+    }
+
+    public function getContext(): Context
+    {
+        return $this->salesChannelContext->getContext();
+    }
+
+    public function getContextToken(): string
+    {
+        return $this->contextToken;
+    }
+
+    public function getSalesChannelId(): string
+    {
+        return $this->salesChannelContext->getSalesChannel()->getId();
+    }
+
+    public static function getAvailableData(): EventDataCollection
+    {
+        return (new EventDataCollection())
+            ->add('customer', new EntityType(CustomerDefinition::class))
+            ->add('contextToken', new ScalarValueType(ScalarValueType::TYPE_STRING));
+    }
+
+    public function getAddressId(): string
+    {
+        return $this->addressId;
+    }
+
+    public function setAddressId(string $addressId): void
+    {
+        $this->addressId = $addressId;
+    }
+}

--- a/src/Core/Checkout/Customer/Event/CustomerSetDefaultShippingAddressEvent.php
+++ b/src/Core/Checkout/Customer/Event/CustomerSetDefaultShippingAddressEvent.php
@@ -1,0 +1,94 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Checkout\Customer\Event;
+
+use Shopware\Core\Checkout\Customer\CustomerDefinition;
+use Shopware\Core\Checkout\Customer\CustomerEntity;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Event\BusinessEventInterface;
+use Shopware\Core\Framework\Event\EventData\EntityType;
+use Shopware\Core\Framework\Event\EventData\EventDataCollection;
+use Shopware\Core\Framework\Event\EventData\ScalarValueType;
+use Shopware\Core\Framework\Event\SalesChannelAware;
+use Shopware\Core\Framework\Event\ShopwareSalesChannelEvent;
+use Shopware\Core\System\SalesChannel\SalesChannelContext;
+use Symfony\Contracts\EventDispatcher\Event;
+
+class CustomerSetDefaultShippingAddressEvent extends Event implements BusinessEventInterface, SalesChannelAware, ShopwareSalesChannelEvent
+{
+    public const EVENT_NAME = 'checkout.customer.default.shipping.address.event';
+
+    /**
+     * @var CustomerEntity
+     */
+    private $customer;
+
+    /**
+     * @var SalesChannelContext
+     */
+    private $salesChannelContext;
+
+    /**
+     * @var string
+     */
+    private $contextToken;
+
+    /**
+     * @var string
+     */
+    private $addressId;
+
+    public function __construct(SalesChannelContext $salesChannelContext, CustomerEntity $customer, string $addressId)
+    {
+        $this->customer = $customer;
+        $this->salesChannelContext = $salesChannelContext;
+        $this->addressId = $addressId;
+    }
+
+    public function getName(): string
+    {
+        return self::EVENT_NAME;
+    }
+
+    public function getCustomer(): CustomerEntity
+    {
+        return $this->customer;
+    }
+
+    public function getSalesChannelContext(): SalesChannelContext
+    {
+        return $this->salesChannelContext;
+    }
+
+    public function getContext(): Context
+    {
+        return $this->salesChannelContext->getContext();
+    }
+
+    public function getContextToken(): string
+    {
+        return $this->contextToken;
+    }
+
+    public function getSalesChannelId(): string
+    {
+        return $this->salesChannelContext->getSalesChannel()->getId();
+    }
+
+    public static function getAvailableData(): EventDataCollection
+    {
+        return (new EventDataCollection())
+            ->add('customer', new EntityType(CustomerDefinition::class))
+            ->add('contextToken', new ScalarValueType(ScalarValueType::TYPE_STRING));
+    }
+
+    public function getAddressId(): string
+    {
+        return $this->addressId;
+    }
+
+    public function setAddressId(string $addressId): void
+    {
+        $this->addressId = $addressId;
+    }
+}

--- a/src/Core/Checkout/DependencyInjection/customer.xml
+++ b/src/Core/Checkout/DependencyInjection/customer.xml
@@ -254,6 +254,7 @@
         <service id="Shopware\Core\Checkout\Customer\SalesChannel\SwitchDefaultAddressRoute" public="true">
             <argument type="service" id="customer_address.repository"/>
             <argument type="service" id="customer.repository"/>
+            <argument type="service" id="Symfony\Component\EventDispatcher\EventDispatcherInterface" />
         </service>
 
         <service id="Shopware\Core\Checkout\Customer\SalesChannel\CustomerGroupRegistrationSettingsRoute" public="true">


### PR DESCRIPTION
### 1. Why is this change necessary?
These events were missing by default in shopware 6. When there have to be restrictions on address for a particular sales channel, the Account service doesn't provide these necessary events and hence leads to Custom Address Controller inheritance.

### 2. What does this change do, exactly?
Add events when an address is set as default shipping or as default billing address



