### PR TITLE
NEXT-10679 - Set total after fetching list items

### DIFF
--- a/changelog/_unreleased/2021-01-14-set-total-after-fetching-list-items.md
+++ b/changelog/_unreleased/2021-01-14-set-total-after-fetching-list-items.md
@@ -1,0 +1,9 @@
+---
+title: Set total after fetching list items
+issue: NEXT-10679
+author: Elias Lackner
+author_email: lackner.elias@gmail.com
+author_github: @lacknere
+---
+# Administration
+* Changed method `getList()` in `sw-settings-list.mixin.js` to set the value of total items.

--- a/src/Administration/Resources/app/administration/src/module/sw-settings/mixin/sw-settings-list.mixin.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings/mixin/sw-settings-list.mixin.js
@@ -79,6 +79,7 @@ Mixin.register('sw-settings-list', {
             this.entityRepository.search(this.listingCriteria, Shopware.Context.api)
                 .then((items) => {
                     this.items = items;
+                    this.total = items.total;
 
                     return this.items;
                 })


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/contribution/contribution-guideline?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
To fix some counter issues in the administration settings pages.

### 2. What does this change do, exactly?
Set the value of total after fetching list items.

### 3. Describe each step to reproduce the issue or behaviour.
Go to settings > documents page for example.

### 4. Please link to the relevant issues (if any).
#205 

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/master/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
