### PR TITLE
NEXT-8427 - Rename ean to gtin

### DIFF
--- a/changelog/_unreleased/2021-03-11-rename-ean-to-gtin.md
+++ b/changelog/_unreleased/2021-03-11-rename-ean-to-gtin.md
@@ -1,0 +1,8 @@
+---
+title: Rename EAN to GTIN
+issue: NEXT-8427
+---
+# Administration
+* Changed translation occurrences of `EAN` to `GTIN`
+* Changed snippet translation key `ean` to `gtin` in `sw-settings-product-feature-sets.modal.label` and `sw-settings-search.generalTab.configField`
+* Changed snippet translation key `labelEan` to `labelGtin` and `placeholderEan` to `placeholderGtin` in `sw-product.settingsForm`

--- a/src/Administration/Resources/app/administration/src/module/sw-product-stream/snippet/de-DE.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-product-stream/snippet/de-DE.json
@@ -53,7 +53,7 @@
         "choose": "Auswahl",
         "description": "Beschreibung",
         "descriptionLong": "Langbeschreibung",
-        "ean": "EAN",
+        "gtin": "GTIN",
         "gross": "Brutto",
         "group": "Gruppe",
         "height": "Höhe",

--- a/src/Administration/Resources/app/administration/src/module/sw-product-stream/snippet/en-GB.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-product-stream/snippet/en-GB.json
@@ -53,7 +53,7 @@
         "choose": "Choose",
         "description": "Description",
         "descriptionLong": "Description long",
-        "ean": "EAN",
+        "gtin": "GTIN",
         "gross": "Gross",
         "group": "Group",
         "height": "Height",

--- a/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-settings-form/sw-product-settings-form.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-settings-form/sw-product-settings-form.html.twig
@@ -36,8 +36,8 @@
                                 type="text"
                                 :mapInheritance="props"
                                 :error="productEanError"
-                                :label="$tc('sw-product.settingsForm.labelEan')"
-                                :placeholder="$tc('sw-product.settingsForm.placeholderEan')"
+                                :label="$tc('sw-product.settingsForm.labelGtin')"
+                                :placeholder="$tc('sw-product.settingsForm.placeholderGtin')"
                                 :disabled="props.isInherited || !allowEdit"
                                 :value="props.currentValue"
                                 @change="props.updateCurrentValue">

--- a/src/Administration/Resources/app/administration/src/module/sw-product/snippet/de-DE.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/snippet/de-DE.json
@@ -100,7 +100,7 @@
       "labelWeight": "Gewicht",
       "labelMinPurchase": "Mindestabnahme",
       "labelMaxPurchase": "Maximalabnahme",
-      "labelEan": "EAN",
+      "labelGtin": "GTIN",
       "labelManufacturerNumber": "Herstellernummer",
       "labelStock": "Lagerbestand",
       "labelActive": "Aktiv",
@@ -122,7 +122,7 @@
       "placeholderMaxPurchase": "Maximalabnahme ...",
       "placeholderPurchaseSteps": "Verkaufsintervall (Stückzahl) ...",
       "placeholderRestockTime": "Wiederauffüllintervall ...",
-      "placeholderEan": "Gib die EAN-Nummer ein ...",
+      "placeholderGtin": "Gib die GTIN ein ...",
       "placeholderManufacturerNumber": "Gib die Herstellernummer ein ...",
       "labelAvailableStock": "Verfügbarer Bestand",
       "labelPurchaseSteps": "Staffelung"

--- a/src/Administration/Resources/app/administration/src/module/sw-product/snippet/en-GB.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/snippet/en-GB.json
@@ -100,7 +100,7 @@
       "labelWeight": "Weight",
       "labelMinPurchase": "Min. order quantity",
       "labelMaxPurchase": "Max. order quantity",
-      "labelEan": "EAN",
+      "labelGtin": "GTIN",
       "labelManufacturerNumber": "Manufacturer product number",
       "labelStock": "Stock",
       "labelActive": "Active",
@@ -122,7 +122,7 @@
       "placeholderMaxPurchase": "Max. amount purchaseable...",
       "placeholderPurchaseSteps": "Enter purchase steps...",
       "placeholderRestockTime": "Enter restock time in days...",
-      "placeholderEan": "Enter EAN number...",
+      "placeholderGtin": "Enter GTIN...",
       "placeholderManufacturerNumber": "Enter product number...",
       "labelAvailableStock": "Available stock",
       "labelPurchaseSteps": "Purchase steps"

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-product-feature-sets/component/sw-settings-product-feature-sets-modal/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-product-feature-sets/component/sw-settings-product-feature-sets-modal/index.js
@@ -157,7 +157,7 @@ Component.register('sw-settings-product-feature-sets-modal', {
                 {
                     id: 'eb6c8ec9b6e24811a176be5a5c9871cf',
                     type: 'product',
-                    label: this.$tc('sw-settings-product-feature-sets.modal.label.ean'),
+                    label: this.$tc('sw-settings-product-feature-sets.modal.label.gtin'),
                     name: 'ean'
                 },
                 {

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-product-feature-sets/snippet/de-DE.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-product-feature-sets/snippet/de-DE.json
@@ -62,7 +62,7 @@
         "releaseDate": "Erscheinungsdatum",
         "description": "Beschreibung",
         "manufacturerNumber": "Herstellernummer",
-        "ean": "EAN",
+        "ean": "GTIN",
         "referencePrice": "Grundpreis"
       }
     }

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-product-feature-sets/snippet/en-GB.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-product-feature-sets/snippet/en-GB.json
@@ -62,7 +62,7 @@
         "releaseDate": "Release date",
         "description": "Description",
         "manufacturerNumber": "Manufacturer product number",
-        "ean": "EAN",
+        "ean": "GTIN",
         "referencePrice": "Unit price"
       }
     }

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-search/component/sw-settings-search-searchable-content/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-search/component/sw-settings-search-searchable-content/index.js
@@ -65,7 +65,7 @@ Component.register('sw-settings-search-searchable-content', {
                     }
                 },
                 {
-                    label: this.$tc('sw-settings-search.generalTab.configFields.ean'),
+                    label: this.$tc('sw-settings-search.generalTab.configFields.gtin'),
                     value: 'ean',
                     defaultConfigs: {
                         searchable: true,

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-search/snippet/de-DE.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-search/snippet/de-DE.json
@@ -66,7 +66,7 @@
         "description": "Beschreibung",
         "productNumber": "Produktnummer",
         "manufacturerNumber": "Herstellernummer",
-        "ean": "EAN",
+        "gtin": "GTIN",
         "customSearchKeywords": "Eigene Suchwörter",
         "manufacturerName": "Hersteller-Name",
         "manufacturerCustomFields": "Hersteller-Zusatzfelder",

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-search/snippet/en-GB.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-search/snippet/en-GB.json
@@ -66,7 +66,7 @@
         "description": "Description",
         "productNumber": "Product number",
         "manufacturerNumber": "Manufacturer number",
-        "ean": "EAN",
+        "gtin": "GTIN",
         "customSearchKeywords": "Custom search keywords",
         "manufacturerName": "Manufacturer name",
         "manufacturerCustomFields": "Manufacturer custom fields",

--- a/src/Storefront/Resources/snippet/de_DE/storefront.de-DE.json
+++ b/src/Storefront/Resources/snippet/de_DE/storefront.de-DE.json
@@ -584,7 +584,7 @@
       "feature": {
         "label": {
           "manufacturerNumber": "Herstellernummer:",
-          "ean": "EAN:",
+          "ean": "GTIN:",
           "weight": "Gewicht:",
           "width":  "Breite:",
           "height": "Höhe:",

--- a/src/Storefront/Resources/snippet/en_GB/storefront.en-GB.json
+++ b/src/Storefront/Resources/snippet/en_GB/storefront.en-GB.json
@@ -584,7 +584,7 @@
       "feature": {
         "label": {
           "manufacturerNumber": "Manufacturer number:",
-          "ean": "EAN:",
+          "ean": "GTIN:",
           "weight": "Weight:",
           "width":  "Width:",
           "height": "Height:",


### PR DESCRIPTION
### 1. Why is this change necessary?
Based on [https://github.com/shopware/platform/pull/890](https://github.com/shopware/platform/pull/890)

### 2. What does this change do, exactly?
Renaming  `EAN` to `GTIN` in the administration and storefront.
As discussed, we don't want to change the entity or the itemprop to the related gtin-type.

We cannot change the key of these snippets while the property in entity is still named "ean":
administration: `sw-settings-product-feature-sets.modal.label.ean``
storefront: `component.product.feature.label.ean`

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
