### PR TITLE
NEXT-13052 - Add product number error to input fixes shopwareBoostday…

### DIFF
--- a/changelog/_unreleased/2021-03-11-add-product-number-error-in-administration.md
+++ b/changelog/_unreleased/2021-03-11-add-product-number-error-in-administration.md
@@ -1,0 +1,9 @@
+---
+title: Add product number error in administration
+issue: NEXT-13052
+author: Sebastian Lember, Timo Boomgaarden
+author_email: lember@hochwarth-it.de, boomgaarden@hochwarth-it.de 
+author_github: sebi007, timoboomgaarden
+---
+# Administration
+*  Added `:error` attribute to product number input in `sw-product-basic-form.html.twig` to show mandatory error

--- a/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-basic-form/sw-product-basic-form.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-basic-form/sw-product-basic-form.html.twig
@@ -48,6 +48,7 @@
                 <sw-field
                     type="text"
                     :disabled="!allowEdit"
+                    :error="productProductNumberError"
                     :label="$tc('sw-product.basicForm.labelProductNumber')"
                     :helpText="productNumberHelpText"
                     v-model="product.productNumber">


### PR DESCRIPTION
…/platform#291

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/contribution/contribution-guideline?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
To see that the field product number is empty

### 2. What does this change do, exactly?
displays an error if the product number is empty in the administration

### 3. Describe each step to reproduce the issue or behaviour.
clear the product number in administration and push the save button

### 4. Please link to the relevant issues (if any).
#291 

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [X] I have squashed any insignificant commits
- [X] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.
