### PR TITLE
NEXT-9698 - Removal of cover in adminstration if last media is deleted

### DIFF
--- a/changelog/_unreleased/2021-01-14-removal-of-in-adminstration-if-last-media-is-deleted.md
+++ b/changelog/_unreleased/2021-01-14-removal-of-in-adminstration-if-last-media-is-deleted.md
@@ -1,0 +1,9 @@
+---
+title: Removal of cover in adminstration if last media is deleted
+issue: NEXT-9698
+author: Max
+author_email: max@swk-web.com
+author_github: @aragon999
+---
+# Administration
+- Changed that if the last media of a product, that the cover is also properly removed

--- a/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-media-form/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-media-form/index.js
@@ -238,11 +238,11 @@ Component.register('sw-product-media-form', {
                 this.product.coverId = null;
             }
 
+            this.product.media.remove(productMedia.id);
+
             if (this.product.coverId === null && this.product.media.length > 0) {
                 this.product.coverId = this.product.media.first().id;
             }
-
-            this.product.media.remove(productMedia.id);
         },
 
         markMediaAsCover(productMedia) {

--- a/src/Administration/Resources/app/administration/test/module/sw-product/component/sw-product-media-form.spec.js
+++ b/src/Administration/Resources/app/administration/test/module/sw-product/component/sw-product-media-form.spec.js
@@ -1,5 +1,6 @@
 import { createLocalVue, shallowMount } from '@vue/test-utils';
 import Vuex from 'vuex';
+import EntityCollection from 'src/core/data/entity-collection.data';
 import 'src/module/sw-product/component/sw-product-media-form';
 
 function createWrapper(privileges = []) {
@@ -11,7 +12,8 @@ function createWrapper(privileges = []) {
     return shallowMount(Shopware.Component.build('sw-product-media-form'), {
         localVue,
         mocks: {
-            $tc: () => {},
+            $tc: () => {
+            },
             $store: new Vuex.Store({
                 modules: {
                     swProductDetail: {
@@ -27,7 +29,9 @@ function createWrapper(privileges = []) {
             repositoryFactory: {},
             acl: {
                 can: (identifier) => {
-                    if (!identifier) { return true; }
+                    if (!identifier) {
+                        return true;
+                    }
 
                     return privileges.includes(identifier);
                 }
@@ -47,6 +51,27 @@ function createWrapper(privileges = []) {
 
 describe('module/sw-product/component/sw-product-media-form', () => {
     beforeAll(() => {
+        const mediaElements = [
+            {
+                mediaId: 'c621b5f556424911964e848fa1b7e8a5',
+                position: 1,
+                id: '520a8b95abc2446db77b173fcd718567',
+                media: {
+                    id: 'c621b5f556424911964e848fa1b7e8a5'
+                }
+            },
+            {
+                mediaId: 'c621b5f556424911964e848fa1b7e8a5',
+                position: 1,
+                id: '5a73a7f88b544a9ab52b2e795c95c7a7',
+                media: {
+                    id: 'c621b5f556424911964e848fa1b7e8a5'
+                }
+            }
+        ];
+
+        const mediaCollection = new EntityCollection('', '', {}, {}, mediaElements);
+
         const product = {
             cover: {
                 mediaId: 'c621b5f556424911964e848fa1b7e8a5',
@@ -57,24 +82,7 @@ describe('module/sw-product/component/sw-product-media-form', () => {
                 }
             },
             coverId: '520a8b95abc2446db77b173fcd718567',
-            media: [
-                {
-                    mediaId: 'c621b5f556424911964e848fa1b7e8a5',
-                    position: 1,
-                    id: '520a8b95abc2446db77b173fcd718567',
-                    media: {
-                        id: 'c621b5f556424911964e848fa1b7e8a5'
-                    }
-                },
-                {
-                    mediaId: 'c621b5f556424911964e848fa1b7e8a5',
-                    position: 1,
-                    id: '5a73a7f88b544a9ab52b2e795c95c7a7',
-                    media: {
-                        id: 'c621b5f556424911964e848fa1b7e8a5'
-                    }
-                }
-            ]
+            media: mediaCollection
         };
         product.getEntityName = () => 'T-Shirt';
 
@@ -128,5 +136,17 @@ describe('module/sw-product/component/sw-product-media-form', () => {
 
         const pageChangeEvents = wrapper.emitted()['media-open'];
         expect(pageChangeEvents.length).toBe(1);
+    });
+
+    it('should remove the cover properly if all medias removed', async () => {
+        const wrapper = createWrapper();
+
+        expect(wrapper.vm.product.cover).toBeTruthy();
+
+        wrapper.vm.mediaItems.forEach(mediaItem => {
+            wrapper.vm.removeFile(mediaItem);
+        });
+
+        expect(wrapper.vm.product.cover).toBe(null);
     });
 });


### PR DESCRIPTION
### 1. Why is this change necessary?
If the last media of a product was removed the cover was not automatically removed.

### 2. What does this change do, exactly?
The problem was, that after the removal of the cover it was set again, since the media was not removed before checking if there is a new cover. Therefore the order of the code is changed, which fixes the issue.

### 3. Describe each step to reproduce the issue or behaviour.
Delete all images of a product.

### 4. Please link to the relevant issues (if any).
https://github.com/shopwareBoostDay/platform/issues/208

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/master/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
