### PR TITLE
NEXT-14171 - Add SitemapSalesChannelCriteriaEvent, fixes shopwareBoos…

### DIFF
--- a/changelog/_unreleased/2021-03-11-add-sitemap-sales-channel-criteria-event.md
+++ b/changelog/_unreleased/2021-03-11-add-sitemap-sales-channel-criteria-event.md
@@ -1,0 +1,10 @@
+---
+title: Add sitemap sales channel criteria event
+issue: NEXT-14171
+author: Sebastian Lember
+author_email: lember@hochwarth-it.de 
+author_github: sebi007
+---
+# Core
+* Added `SitemapSalesChannelCriteriaEvent`
+* Added event dispatcher event to change sales channel criteria when generating sitemaps

--- a/src/Core/Content/Sitemap/Commands/SitemapGenerateCommand.php
+++ b/src/Core/Content/Sitemap/Commands/SitemapGenerateCommand.php
@@ -2,6 +2,7 @@
 
 namespace Shopware\Core\Content\Sitemap\Commands;
 
+use Shopware\Core\Content\Sitemap\Event\SitemapSalesChannelCriteriaEvent;
 use Shopware\Core\Content\Sitemap\Exception\AlreadyLockedException;
 use Shopware\Core\Content\Sitemap\Service\SitemapExporterInterface;
 use Shopware\Core\Defaults;
@@ -19,6 +20,7 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
 class SitemapGenerateCommand extends Command
 {
@@ -30,16 +32,20 @@ class SitemapGenerateCommand extends Command
 
     private SalesChannelContextFactory $salesChannelContextFactory;
 
+    private EventDispatcherInterface $eventDispatcher;
+
     public function __construct(
         EntityRepositoryInterface $salesChannelRepository,
         SitemapExporterInterface $sitemapExporter,
-        SalesChannelContextFactory $salesChannelContextFactory
+        SalesChannelContextFactory $salesChannelContextFactory,
+        EventDispatcherInterface $eventDispatcher
     ) {
         parent::__construct();
 
         $this->salesChannelRepository = $salesChannelRepository;
         $this->sitemapExporter = $sitemapExporter;
         $this->salesChannelContextFactory = $salesChannelContextFactory;
+        $this->eventDispatcher = $eventDispatcher;
     }
 
     /**
@@ -73,6 +79,10 @@ class SitemapGenerateCommand extends Command
         $context = Context::createDefaultContext();
 
         $criteria = $this->createCriteria($salesChannelId);
+
+        $this->eventDispatcher->dispatch(
+            new SitemapSalesChannelCriteriaEvent($criteria)
+        );
 
         $salesChannels = $this->salesChannelRepository->search($criteria, $context);
 

--- a/src/Core/Content/Sitemap/Event/SitemapSalesChannelCriteriaEvent.php
+++ b/src/Core/Content/Sitemap/Event/SitemapSalesChannelCriteriaEvent.php
@@ -1,0 +1,21 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Content\Sitemap\Event;
+
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Symfony\Contracts\EventDispatcher\Event;
+
+class SitemapSalesChannelCriteriaEvent extends Event
+{
+    private Criteria $criteria;
+
+    public function __construct(Criteria $criteria)
+    {
+        $this->criteria = $criteria;
+    }
+
+    public function getCriteria(): Criteria
+    {
+        return $this->criteria;
+    }
+}

--- a/src/Core/Content/Sitemap/ScheduledTask/SitemapGenerateTaskHandler.php
+++ b/src/Core/Content/Sitemap/ScheduledTask/SitemapGenerateTaskHandler.php
@@ -3,6 +3,7 @@
 namespace Shopware\Core\Content\Sitemap\ScheduledTask;
 
 use Psr\Log\LoggerInterface;
+use Shopware\Core\Content\Sitemap\Event\SitemapSalesChannelCriteriaEvent;
 use Shopware\Core\Content\Sitemap\Exception\AlreadyLockedException;
 use Shopware\Core\Content\Sitemap\Service\SitemapExporterInterface;
 use Shopware\Core\Defaults;
@@ -18,6 +19,7 @@ use Shopware\Core\System\SalesChannel\Context\SalesChannelContextService;
 use Shopware\Core\System\SalesChannel\SalesChannelEntity;
 use Shopware\Core\System\SystemConfig\SystemConfigService;
 use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
 class SitemapGenerateTaskHandler extends ScheduledTaskHandler
 {
@@ -33,6 +35,8 @@ class SitemapGenerateTaskHandler extends ScheduledTaskHandler
 
     private MessageBusInterface $messageBus;
 
+    private EventDispatcherInterface $eventDispatcher;
+
     public function __construct(
         EntityRepositoryInterface $scheduledTaskRepository,
         EntityRepositoryInterface $salesChannelRepository,
@@ -40,7 +44,8 @@ class SitemapGenerateTaskHandler extends ScheduledTaskHandler
         SitemapExporterInterface $sitemapExporter,
         LoggerInterface $logger,
         SystemConfigService $systemConfigService,
-        MessageBusInterface $messageBus
+        MessageBusInterface $messageBus,
+        EventDispatcherInterface $eventDispatcher
     ) {
         parent::__construct($scheduledTaskRepository);
         $this->salesChannelRepository = $salesChannelRepository;
@@ -49,6 +54,7 @@ class SitemapGenerateTaskHandler extends ScheduledTaskHandler
         $this->logger = $logger;
         $this->systemConfigService = $systemConfigService;
         $this->messageBus = $messageBus;
+        $this->eventDispatcher = $eventDispatcher;
     }
 
     public static function getHandledMessages(): iterable
@@ -73,6 +79,10 @@ class SitemapGenerateTaskHandler extends ScheduledTaskHandler
             NotFilter::CONNECTION_AND,
             [new EqualsFilter('type.id', Defaults::SALES_CHANNEL_TYPE_API)]
         ));
+
+        $this->eventDispatcher->dispatch(
+            new SitemapSalesChannelCriteriaEvent($criteria)
+        );
 
         $salesChannels = $this->salesChannelRepository->search($criteria, Context::createDefaultContext())->getEntities();
 

--- a/src/Core/Content/Test/Sitemap/ScheduledTask/SitemapGenerateTaskHandlerTest.php
+++ b/src/Core/Content/Test/Sitemap/ScheduledTask/SitemapGenerateTaskHandlerTest.php
@@ -53,7 +53,8 @@ class SitemapGenerateTaskHandlerTest extends TestCase
             $this->getContainer()->get(SitemapExporter::class),
             $this->getContainer()->get('logger'),
             $this->getContainer()->get(SystemConfigService::class),
-            $this->messageBusMock
+            $this->messageBusMock,
+            $this->getContainer()->get('event_dispatcher')
         );
         $this->salesChannelDomainRepository = $this->getContainer()->get('sales_channel_domain.repository');
     }


### PR DESCRIPTION
…tday/platform#300

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/contribution/contribution-guideline?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
Some extensions which adds a own sales channel like Shopware Markets needs an event to remove their own sales channel from the sitemap generation

### 2. What does this change do, exactly?
This change adds an event where extension manufacturers can change the criteria object for loading the sales channel when generation sitemaps.

### 3. Describe each step to reproduce the issue or behaviour.
- Create sales channel which should not be in the sitemap
- Run sitemap:generate command

### 4. Please link to the relevant issues (if any).
#300 

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [X] I have squashed any insignificant commits
- [X] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.
