### PR TITLE
NEXT-13578 - Product detail view does not show first product image fr…

### DIFF
--- a/changelog/_unreleased/2021-05-27-Product-detail-view-does-not-show-first-product-image-from-the-media-gallery.md
+++ b/changelog/_unreleased/2021-05-27-Product-detail-view-does-not-show-first-product-image-from-the-media-gallery.md
@@ -1,0 +1,11 @@
+---
+title: Product detail view does not show first product image from the media gallery
+issue: NEXT-13578
+flag:
+author: Timo Boomgaarden
+author_email: boomgaarden@hochwarth.de
+author_github: timoboomgaarden
+---
+# Storefront
+* Changed twig variable value `startIndexThumbnails` in `src/Storefront/Resources/views/storefront/page/product-detail/index.html.twig`
+* Removed unused variable `startIndexSlider` from `src/Storefront/Resources/views/storefront/page//product-detail/index.html.twig`

--- a/src/Storefront/Resources/views/storefront/page/product-detail/index.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/product-detail/index.html.twig
@@ -38,8 +38,7 @@
                                                 'galleryPosition': 'left',
                                                 'isProduct': true,
                                                 'fallbackImageTitle': page.product.translated.name,
-                                                'startIndexThumbnails': page.product.cover.position + 1,
-                                                'startIndexSlider': page.product.cover.position + 1
+                                                'startIndexThumbnails': 1
                                             } %}
                                         {% endif %}
                                     </div>


### PR DESCRIPTION
…om the media gallery

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/contribution/contribution-guideline?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
Show the first Image of the Product


### 2. What does this change do, exactly?
Change the gallery image start point


### 3. Describe each step to reproduce the issue or behaviour.
- Add more then one Image to a Product
- chenge the order of the Images
- view the Product

### 4. Please link to the relevant issues (if any).
#288 NEXT-13578

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [X] I have squashed any insignificant commits
- [X] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.
