### PR TITLE
NEXT-9332 - Add config options for autoplay, autoplayTimeout, slideAn…

### DIFF
--- a/changelog/_unreleased/2021-12-16-add-autoplay-to-image-slider.md
+++ b/changelog/_unreleased/2021-12-16-add-autoplay-to-image-slider.md
@@ -1,0 +1,13 @@
+---
+title: Add autoplay to image slider
+issue: NEXT-9332
+author: Sebastian Lember
+author_email: sebi.lember@gmx.de 
+author_github: sebi007
+---
+# Administration
+* Added config options to image slider for `autoplay`, `autoplayTimeout` and `slideAnimationSpeed`
+___
+# Storefront
+*  Added `autoplay`, `autoplayTimeout` and `slideAnimationSpeed` to baseSliderConfig in `Storefront/Resources/views/storefront/element/cms-element-image-slider.html.twig`
+___

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/image-slider/config/sw-cms-el-config-image-slider.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/image-slider/config/sw-cms-el-config-image-slider.html.twig
@@ -172,6 +172,32 @@
                     </div>
                     {% endblock %}
 
+                    {% block sw_cms_element_image_slider_config_autoplay %}
+                        <div class="sw-cms-el-config-image-slider__setting-autoplay">
+                            <sw-container columns="1.5fr 1fr 1.5fr" gap="0 30px">
+                                <sw-field
+                                    type="number"
+                                    v-model="element.config.slideAnimationSpeed.value"
+                                    :label="$tc('sw-cms.elements.imageSlider.config.label.slideAnimationSpeed')">
+                                </sw-field>
+
+                                <sw-field
+                                    type="switch"
+                                    v-model="element.config.autoplay.value"
+                                    :label="$tc('sw-cms.elements.imageSlider.config.label.autoplay')">
+                                </sw-field>
+
+                                <sw-field
+                                    v-if="element.config.autoplay.value"
+                                    v-model="element.config.autoplayTimeout.value"
+                                    type="number"
+                                    :label="$tc('sw-cms.elements.imageSlider.config.label.autoplayTimeout')">
+                                </sw-field>
+                            </sw-container>
+                        </div>
+                    {% endblock %}
+
+
                     {% block sw_cms_element_image_slider_config_settings_links %}
                     <div class="sw-cms-el-config-image-slider__settings-links sw-cms-el-config-image-slider__setting-option">
                         <div

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/image-slider/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/image-slider/index.js
@@ -37,6 +37,18 @@ Shopware.Service('cmsService').registerCmsElement({
             source: 'static',
             value: null,
         },
+        autoplay: {
+            source: 'static',
+            value: false,
+        },
+        autoplayTimeout: {
+            source: 'static',
+            value: 5000,
+        },
+        slideAnimationSpeed: {
+            source: 'static',
+            value: 500,
+        },
     },
     enrich: function enrich(elem, data) {
         if (Object.keys(data).length < 1) {

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/snippet/de-DE.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/snippet/de-DE.json
@@ -228,7 +228,10 @@
             "navigationPositionNone": "Keine",
             "navigationPositionInside": "Innen",
             "navigationPositionOutside": "Außen",
-            "navigationDots": "Punkte-Navigation"
+            "navigationDots": "Punkte-Navigation",
+            "slideAnimationSpeed": "Geschwindigkeit Slide Animation (in ms)",
+            "autoplay": "Autoplay",
+            "autoplayTimeout": "Zeit zwischen 2 Bildern (in ms)"
           }
         }
       },

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/snippet/en-GB.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/snippet/en-GB.json
@@ -228,7 +228,10 @@
             "navigationPositionNone": "None",
             "navigationPositionInside": "Inside",
             "navigationPositionOutside": "Outside",
-            "navigationDots": "Dots navigation"
+            "navigationDots": "Dots navigation",
+            "slideAnimationSpeed": "Slide animation speed (in ms)",
+            "autoplay": "Autoplay",
+            "autoplayTimeout": "Time between 2 slides (in ms)"
           }
         }
       },

--- a/src/Storefront/Resources/views/storefront/element/cms-element-image-slider.html.twig
+++ b/src/Storefront/Resources/views/storefront/element/cms-element-image-slider.html.twig
@@ -5,7 +5,10 @@
         {% set baseSliderOptions = {
             slider: {
                 navPosition: 'bottom',
-                speed: 500,
+                speed: (sliderConfig.slideAnimationSpeed is defined) ? sliderConfig.slideAnimationSpeed.value : 500,
+                autoplay: (sliderConfig.autoplay is defined) ? sliderConfig.autoplay.value : false,
+                autoplayTimeout: (sliderConfig.autoplayTimeout is defined) ? sliderConfig.autoplayTimeout.value : 5000,
+                autoplayButtonOutput: false,
                 nav: sliderConfig.navigationDots.value ? true : false,
                 controls: sliderConfig.navigationArrows.value ? true : false,
                 autoHeight: (sliderConfig.displayMode.value == "standard") ? true : false


### PR DESCRIPTION
…imationSpeed to image slider element, fixes shopwareBoostday/platform#420

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/contribution/contribution-guideline?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
This change is necessary to add autoplay functionality to the image slider cms element

### 2. What does this change do, exactly?
This change adds config options autoplay, autoplayTimeout and slideAnimationSpeed to the image slider cms element.

### 3. Describe each step to reproduce the issue or behaviour.
Create a cms page, add an image slider element to the page. Now go to the slider options. There is no way to configure autoplay

### 4. Please link to the relevant issues (if any).
#420 

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [X] I have squashed any insignificant commits
- [X] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.
