### PR TITLE
NEXT-12695 - Prevent jumping of "X" in offcanvas (cart-item-remove), fixes shopwareBoostday/platform#397

### DIFF
--- a/changelog/_unreleased/2021-12-16-prevent-jumping-of-x-in-offcanvas-cart.md
+++ b/changelog/_unreleased/2021-12-16-prevent-jumping-of-x-in-offcanvas-cart.md
@@ -1,0 +1,10 @@
+---
+title: Prevent jumping of "X" in offcanvas (cart-item-remove)
+issue: NEXT-12695
+author: Johannes Dachsel
+author_email: dachsel@hochwarth-it.de
+author_github: johannesdachsel
+___
+# Storefront
+*  Added CSS to prevent remove item button in offcanvas cart from shifting a few pixels when clicked. 
+___

--- a/src/Storefront/Resources/app/storefront/src/scss/layout/_offcanvas-cart.scss
+++ b/src/Storefront/Resources/app/storefront/src/scss/layout/_offcanvas-cart.scss
@@ -36,6 +36,12 @@ Extends the basic offcanvas component with additional cart styles.
         }
     }
 
+    .cart-item-row {
+        position: relative;
+        margin-right: 0;
+        margin-left: 0;
+    }
+
     .cart-item-img {
         height: 75px;
         width: 75px;
@@ -76,7 +82,7 @@ Extends the basic offcanvas component with additional cart styles.
 
     .cart-item-remove {
         position: absolute;
-        right: 10px;
+        right: 0;
     }
 
     .cart-quantity-price {


### PR DESCRIPTION
### 1. Why is this change necessary?
Prevent the 'remove item' button (x) in the off canvas cart from jumping when being clicked.

### 2. What does this change do, exactly?
Add CSS declarations to cart item wrapper and cart remove component.

### 3. Describe each step to reproduce the issue or behaviour.
Click on the (x) 'remove item' button in the off canvas cart.

### 4. Please link to the relevant issues (if any).
#397 

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
