### PR TITLE
NEXT-19312 - Remove min height from images when display mode is not c…

### DIFF
--- a/changelog/_unreleased/2021-12-16-remove-min-height-from-images-when-display-mode-is-not-cover.md
+++ b/changelog/_unreleased/2021-12-16-remove-min-height-from-images-when-display-mode-is-not-cover.md
@@ -1,0 +1,10 @@
+---
+title: Remove min height from images when display mode is not cover
+issue: NEXT-19312
+author: Marius Faber
+author_email: mariusfaber98@gmail.com 
+author_github: marius-faber
+---
+# Administration
+*  Removed min height from the image element and the image slider when display mode is not cover
+___

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/image-slider/component/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/image-slider/component/index.js
@@ -60,15 +60,17 @@ Component.register('sw-cms-el-image-slider', {
         },
 
         styles() {
-            if (this.element.config.displayMode.value === 'cover' &&
-                this.element.config.minHeight.value &&
-                this.element.config.minHeight.value !== 0) {
-                return {
-                    'min-height': this.element.config.minHeight.value,
-                };
+            const { displayMode, minHeight } = this.element.config;
+
+            if (displayMode.value !== 'cover') {
+                return {};
             }
 
-            return {};
+            return {
+                'min-height': displayMode.value === 'cover' && minHeight.value && minHeight.value !== 0
+                    ? minHeight.value
+                    : '300px',
+            };
         },
 
         outsideNavArrows() {

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/image/component/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/image/component/index.js
@@ -20,10 +20,16 @@ Component.register('sw-cms-el-image', {
         },
 
         styles() {
+            const { displayMode, minHeight } = this.element.config;
+
+            if (displayMode.value !== 'cover') {
+                return {};
+            }
+
             return {
-                'min-height': this.element.config.displayMode.value === 'cover' &&
-                              this.element.config.minHeight.value &&
-                              this.element.config.minHeight.value !== 0 ? this.element.config.minHeight.value : '340px',
+                'min-height': displayMode.value === 'cover' && minHeight.value && minHeight.value !== 0
+                    ? minHeight.value
+                    : '340px',
             };
         },
 


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/contribution/contribution-guideline?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
The image element should not add a min height to images when the display mode is standard or stretch since min height is not needed in this display modes, this also applies to the image slider.

Currently, the added min height results in a broken layout inside the admin when the height of the images is less than 340px and the display mode is not cover.

![Bildschirmfoto von 2021-12-16 13-19-26](https://user-images.githubusercontent.com/45321033/146375904-e2c70cad-3aec-4092-b51e-53d572b9a8c5.png)

### 2. What does this change do, exactly?
Removing the min height from the image element and image slider when the display mode is not cover.

![Bildschirmfoto von 2021-12-16 13-58-10](https://user-images.githubusercontent.com/45321033/146376369-d70018f7-d41f-413b-ab71-0b381cd8028f.png)


### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/NEXT-19312

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
